### PR TITLE
Implement DashboardService and AnalyticsService

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,7 @@
+from .analytics_service import AnalyticsService
+from .dashboard_service import DashboardService
+
+__all__ = [
+    'AnalyticsService',
+    'DashboardService',
+]

--- a/services/aggregators/__init__.py
+++ b/services/aggregators/__init__.py
@@ -1,0 +1,7 @@
+from .user_aggregator import UserAggregator
+from .event_aggregator import EventAggregator
+
+__all__ = [
+    'UserAggregator',
+    'EventAggregator',
+]

--- a/services/aggregators/event_aggregator.py
+++ b/services/aggregators/event_aggregator.py
@@ -1,0 +1,11 @@
+class EventAggregator:
+    """Aggregates event related metrics."""
+
+    def __init__(self, events=None):
+        self.events = list(events) if events else []
+
+    def collect(self):
+        total_events = len(self.events)
+        return {
+            'total_events': total_events,
+        }

--- a/services/aggregators/user_aggregator.py
+++ b/services/aggregators/user_aggregator.py
@@ -1,0 +1,14 @@
+class UserAggregator:
+    """Aggregates user related metrics."""
+
+    def __init__(self, users=None):
+        # In a real implementation this might query a repository or database
+        self.users = list(users) if users else []
+
+    def collect(self):
+        total_users = len(self.users)
+        active_users = len([u for u in self.users if u.get('active')])
+        return {
+            'total_users': total_users,
+            'active_users': active_users,
+        }

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,0 +1,22 @@
+class AnalyticsService:
+    """Collects metrics from registered aggregators."""
+
+    def __init__(self, aggregators=None):
+        self.aggregators = list(aggregators) if aggregators else []
+
+    def register_aggregator(self, aggregator):
+        """Register an aggregator that provides metrics."""
+        self.aggregators.append(aggregator)
+
+    def gather_metrics(self):
+        """Gather metrics from all registered aggregators."""
+        metrics = {}
+        for aggregator in self.aggregators:
+            try:
+                data = aggregator.collect()
+                if isinstance(data, dict):
+                    metrics.update(data)
+            except Exception:
+                # In real code you might log this event.
+                pass
+        return metrics

--- a/services/dashboard_service.py
+++ b/services/dashboard_service.py
@@ -1,0 +1,29 @@
+from .analytics_service import AnalyticsService
+
+
+class DashboardService:
+    """Provides summary metrics for dashboard controllers."""
+
+    def __init__(self, analytics_service: AnalyticsService, aggregators=None):
+        self.analytics_service = analytics_service
+        self.aggregators = list(aggregators) if aggregators else []
+        for agg in self.aggregators:
+            self.analytics_service.register_aggregator(agg)
+
+    def get_summary_metrics(self):
+        """Return combined metrics from all aggregators."""
+        return self.analytics_service.gather_metrics()
+
+    def get_user_metrics(self):
+        """Return user related metrics if a UserAggregator is present."""
+        for agg in self.aggregators:
+            if agg.__class__.__name__ == 'UserAggregator':
+                return agg.collect()
+        return {}
+
+    def get_event_metrics(self):
+        """Return event related metrics if an EventAggregator is present."""
+        for agg in self.aggregators:
+            if agg.__class__.__name__ == 'EventAggregator':
+                return agg.collect()
+        return {}


### PR DESCRIPTION
## Summary
- add initial service modules under `services/`
- implement `AnalyticsService` for registering and gathering metrics
- implement `DashboardService` that injects `AnalyticsService` and aggregators
- provide example aggregators for users and events

## Testing
- `python3 -m py_compile services/*.py services/aggregators/*.py`
- `python3 - <<'EOF'
from services import AnalyticsService, DashboardService
from services.aggregators import UserAggregator, EventAggregator

users = [{'id': 1, 'active': True}, {'id': 2, 'active': False}]
events = [{'id': 1}, {'id': 2}]

analytics = AnalyticsService()

dash = DashboardService(analytics_service=analytics, aggregators=[UserAggregator(users), EventAggregator(events)])
print('Summary:', dash.get_summary_metrics())
print('User metrics:', dash.get_user_metrics())
print('Event metrics:', dash.get_event_metrics())
EOF

------
https://chatgpt.com/codex/tasks/task_e_6848ae6b4ba48322a46f7fa1d41553ec