### PR TITLE
Add aggregator utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # rhythm-backend
+
+This project provides a few utility modules that can be consumed by a higher
+level `DashboardService`.
+
+- `timer.aggregator.ts` – gather time-based data from events.
+- `deadline.aggregator.ts` – analyze upcoming deadlines for tasks.
+- `conflict.detector.ts` – detect and report scheduling conflicts.

--- a/src/conflict.detector.ts
+++ b/src/conflict.detector.ts
@@ -1,0 +1,29 @@
+export interface ScheduleItem {
+  start: Date;
+  end: Date;
+  description?: string;
+}
+
+export interface Conflict {
+  a: ScheduleItem;
+  b: ScheduleItem;
+}
+
+export class ConflictDetector {
+  /**
+   * Detect overlapping schedule items.
+   */
+  detectConflicts(items: ScheduleItem[]): Conflict[] {
+    const conflicts: Conflict[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const current = items[i];
+      for (let j = i + 1; j < items.length; j++) {
+        const other = items[j];
+        if (current.end > other.start && current.start < other.end) {
+          conflicts.push({ a: current, b: other });
+        }
+      }
+    }
+    return conflicts;
+  }
+}

--- a/src/deadline.aggregator.ts
+++ b/src/deadline.aggregator.ts
@@ -1,0 +1,13 @@
+export interface Task {
+  title: string;
+  dueDate: Date;
+}
+
+export class DeadlineAggregator {
+  /**
+   * Return tasks with deadlines after the provided date.
+   */
+  getUpcomingDeadlines(tasks: Task[], from: Date = new Date()): Task[] {
+    return tasks.filter(task => task.dueDate.getTime() > from.getTime());
+  }
+}

--- a/src/timer.aggregator.ts
+++ b/src/timer.aggregator.ts
@@ -1,0 +1,15 @@
+export interface TimeEvent {
+  start: Date;
+  end: Date;
+}
+
+export class TimerAggregator {
+  /**
+   * Aggregate the total duration from a list of events.
+   */
+  aggregateTimeData(events: TimeEvent[]): number {
+    return events.reduce((sum, event) => {
+      return sum + (event.end.getTime() - event.start.getTime());
+    }, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `TimerAggregator` for time based events
- implement `DeadlineAggregator` for tasks with due dates
- implement `ConflictDetector` for overlapping schedule items
- document the new utilities in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ae6f6d388322baacc9166445e463