### PR TITLE
Add analytics utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # rhythm-backend
+
+This project houses backend utilities and services for rhythm-related applications.
+
+## Analytics Module
+
+The `analytics.js` file exposes helper functions and classes that can be used by
+`AnalyticsService` to perform heavy computations. It currently provides:
+
+- `calculateTotal` – Sum values in an array.
+- `calculateAverage` – Compute an average from values in an array.
+- `TrendAnalyzer` – Class for calculating moving averages to analyze trends.
+

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Calculate the sum of an array of numbers or objects.
+ * @param {Array<number|object>} data - Array of numbers or objects.
+ * @param {Function} [selector] - Optional function to select numeric value from each element.
+ * @returns {number} Sum of numeric values.
+ */
+function calculateTotal(data, selector) {
+  if (!Array.isArray(data)) {
+    throw new TypeError('Data must be an array');
+  }
+  const pick = typeof selector === 'function' ? selector : (x => x);
+  return data.reduce((total, item) => {
+    const value = Number(pick(item));
+    if (!Number.isFinite(value)) {
+      throw new TypeError('All values must be numeric');
+    }
+    return total + value;
+  }, 0);
+}
+
+/**
+ * Calculate the average of an array of numbers or objects.
+ * @param {Array<number|object>} data - Array of numbers or objects.
+ * @param {Function} [selector] - Optional function to select numeric value from each element.
+ * @returns {number} Average of numeric values.
+ */
+function calculateAverage(data, selector) {
+  if (data.length === 0) {
+    return 0;
+  }
+  return calculateTotal(data, selector) / data.length;
+}
+
+/**
+ * Class used to analyze simple trends in numeric data.
+ */
+class TrendAnalyzer {
+  /**
+   * @param {Array<number>} data - Array of numeric values.
+   */
+  constructor(data) {
+    if (!Array.isArray(data)) {
+      throw new TypeError('Data must be an array');
+    }
+    this.data = data.map(Number);
+  }
+
+  /**
+   * Compute the moving average over a given period.
+   * @param {number} period - Number of data points in each average window.
+   * @returns {Array<number>} Array of moving average values.
+   */
+  movingAverage(period) {
+    if (!Number.isInteger(period) || period <= 0) {
+      throw new TypeError('Period must be a positive integer');
+    }
+    if (this.data.length < period) {
+      return [];
+    }
+    const result = [];
+    for (let i = 0; i <= this.data.length - period; i++) {
+      const window = this.data.slice(i, i + period);
+      const avg = window.reduce((sum, val) => sum + val, 0) / period;
+      result.push(avg);
+    }
+    return result;
+  }
+}
+
+module.exports = {
+  calculateTotal,
+  calculateAverage,
+  TrendAnalyzer
+};


### PR DESCRIPTION
## Summary
- add `analytics.js` with helper methods to compute totals, averages and moving average trends
- expand README with description of the analytics module

## Testing
- `node - <<'NODE'
const { calculateTotal, calculateAverage, TrendAnalyzer } = require('./analytics');
console.log(calculateTotal([1,2,3]));
console.log(calculateAverage([1,2,3]));
console.log(new TrendAnalyzer([1,2,3,4]).movingAverage(2));
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848ae6e20648322b645a58152eb7141