### PR TITLE
Add basic auth and company modules

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,0 +1,32 @@
+import { Request, Response, Router } from 'express';
+import { AuthService } from './auth.service';
+import { authGuard } from './guards/auth.guard';
+
+export class AuthController {
+  public router: Router = Router();
+  private service = new AuthService();
+
+  constructor() {
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes() {
+    this.router.post('/login', this.login);
+    this.router.post('/signup', this.signup);
+    this.router.get('/me', authGuard, this.me);
+  }
+
+  private login = async (req: Request, res: Response) => {
+    const token = await this.service.login(req.body);
+    res.json(token);
+  };
+
+  private signup = async (req: Request, res: Response) => {
+    const user = await this.service.signup(req.body);
+    res.json(user);
+  };
+
+  private me = (req: Request, res: Response) => {
+    res.json({ user: (req as any).user || null });
+  };
+}

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+import { AuthController } from './auth.controller';
+
+const controller = new AuthController();
+export const authRouter: Router = controller.router;

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,0 +1,14 @@
+import { LoginDto } from './dto/login.dto';
+import { SignupDto } from './dto/signup.dto';
+
+export class AuthService {
+  async login(credentials: LoginDto) {
+    // TODO: check credentials against database
+    return { token: `token-for-${credentials.email}` };
+  }
+
+  async signup(details: SignupDto) {
+    // TODO: create user record in database
+    return { id: Date.now().toString(), ...details };
+  }
+}

--- a/src/modules/auth/dto/login.dto.ts
+++ b/src/modules/auth/dto/login.dto.ts
@@ -1,0 +1,4 @@
+export interface LoginDto {
+  email: string;
+  password: string;
+}

--- a/src/modules/auth/dto/signup.dto.ts
+++ b/src/modules/auth/dto/signup.dto.ts
@@ -1,0 +1,5 @@
+export interface SignupDto {
+  email: string;
+  password: string;
+  name: string;
+}

--- a/src/modules/auth/guards/auth.guard.ts
+++ b/src/modules/auth/guards/auth.guard.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { JwtStrategy } from '../strategies/jwt.strategy';
+
+const jwt = new JwtStrategy();
+
+export function authGuard(req: Request, res: Response, next: NextFunction) {
+  const token = req.headers.authorization;
+  if (token && jwt.verify(token)) {
+    return next();
+  }
+  res.status(401).json({ message: 'Unauthorized' });
+}

--- a/src/modules/auth/guards/roles.guard.ts
+++ b/src/modules/auth/guards/roles.guard.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function rolesGuard(requiredRole: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const userRole = (req as any).user?.role;
+    if (userRole === requiredRole) {
+      return next();
+    }
+    res.status(403).json({ message: 'Forbidden' });
+  };
+}

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,6 @@
+export class JwtStrategy {
+  verify(token: string): boolean {
+    // TODO: Implement real JWT verification
+    return !!token;
+  }
+}

--- a/src/modules/auth/strategies/magiclink.strategy.ts
+++ b/src/modules/auth/strategies/magiclink.strategy.ts
@@ -1,0 +1,6 @@
+export class MagicLinkStrategy {
+  consume(token: string): boolean {
+    // TODO: Implement magic link consumption
+    return !!token;
+  }
+}

--- a/src/modules/auth/strategies/oauth.strategy.ts
+++ b/src/modules/auth/strategies/oauth.strategy.ts
@@ -1,0 +1,6 @@
+export class OAuthStrategy {
+  authenticate(providerToken: string): boolean {
+    // TODO: Implement provider OAuth validation
+    return !!providerToken;
+  }
+}

--- a/src/modules/companies/companies.controller.ts
+++ b/src/modules/companies/companies.controller.ts
@@ -1,0 +1,41 @@
+import { Request, Response, Router } from 'express';
+import { CompaniesService } from './companies.service';
+import { MembersService } from './members.service';
+import { InvitationsService } from './invitations.service';
+import { authGuard } from '../auth/guards/auth.guard';
+
+export class CompaniesController {
+  public router: Router = Router();
+  private companies = new CompaniesService();
+  private members = new MembersService();
+  private invitations = new InvitationsService();
+
+  constructor() {
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes() {
+    this.router.post('/', authGuard, this.create);
+    this.router.get('/', authGuard, this.list);
+    this.router.post('/:id/invite', authGuard, this.invite);
+  }
+
+  private create = async (req: Request, res: Response) => {
+    const company = await this.companies.create(req.body);
+    res.json(company);
+  };
+
+  private list = async (_req: Request, res: Response) => {
+    const companies = await this.companies.findAll();
+    res.json(companies);
+  };
+
+  private invite = async (req: Request, res: Response) => {
+    const invitation = await this.invitations.invite({
+      companyId: req.params.id,
+      email: req.body.email,
+    });
+    await this.members.addMember(req.params.id, req.body.email);
+    res.json(invitation);
+  };
+}

--- a/src/modules/companies/companies.routes.ts
+++ b/src/modules/companies/companies.routes.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+import { CompaniesController } from './companies.controller';
+
+const controller = new CompaniesController();
+export const companiesRouter: Router = controller.router;

--- a/src/modules/companies/companies.service.ts
+++ b/src/modules/companies/companies.service.ts
@@ -1,0 +1,15 @@
+import { CreateCompanyDto } from './dto/create-company.dto';
+
+export class CompaniesService {
+  private companies: any[] = [];
+
+  async create(dto: CreateCompanyDto) {
+    const newCompany = { id: Date.now().toString(), ...dto };
+    this.companies.push(newCompany);
+    return newCompany;
+  }
+
+  async findAll() {
+    return this.companies;
+  }
+}

--- a/src/modules/companies/dto/create-company.dto.ts
+++ b/src/modules/companies/dto/create-company.dto.ts
@@ -1,0 +1,3 @@
+export interface CreateCompanyDto {
+  name: string;
+}

--- a/src/modules/companies/dto/invite-member.dto.ts
+++ b/src/modules/companies/dto/invite-member.dto.ts
@@ -1,0 +1,4 @@
+export interface InviteMemberDto {
+  companyId: string;
+  email: string;
+}

--- a/src/modules/companies/invitations.service.ts
+++ b/src/modules/companies/invitations.service.ts
@@ -1,0 +1,11 @@
+import { InviteMemberDto } from './dto/invite-member.dto';
+
+export class InvitationsService {
+  private invites: any[] = [];
+
+  async invite(dto: InviteMemberDto) {
+    const invitation = { id: Date.now().toString(), ...dto };
+    this.invites.push(invitation);
+    return invitation;
+  }
+}

--- a/src/modules/companies/members.service.ts
+++ b/src/modules/companies/members.service.ts
@@ -1,0 +1,9 @@
+export class MembersService {
+  private members: any[] = [];
+
+  async addMember(companyId: string, email: string) {
+    const member = { id: Date.now().toString(), companyId, email };
+    this.members.push(member);
+    return member;
+  }
+}


### PR DESCRIPTION
## Summary
- add simple TypeScript express modules for auth and companies
- include controllers, services, routes, strategies, guards, and DTOs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848cc20bf64832296cc10ed0b676e73