### PR TITLE
Add time tracking module and scheduler

### DIFF
--- a/backend/src/common/guards/company.guard.ts
+++ b/backend/src/common/guards/company.guard.ts
@@ -1,0 +1,130 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/**
+ * Company guard middleware
+ * Ensures user has access to the company they're trying to access
+ */
+export async function companyGuard(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const user = (req as any).user;
+    
+    if (!user) {
+      res.status(401).json({
+        success: false,
+        error: 'Authentication required',
+      });
+      return;
+    }
+
+    // Get company ID from various sources
+    let companyId = req.body.companyId || 
+                    req.query.companyId || 
+                    req.params.companyId ||
+                    req.headers['x-company-id'];
+
+    // If no company ID provided, get user's default company
+    if (!companyId) {
+      const userWithCompanies = await prisma.user.findUnique({
+        where: { id: user.id },
+        include: {
+          companies: {
+            where: { isDefault: true },
+            take: 1,
+          },
+        },
+      });
+
+      if (userWithCompanies?.companies.length > 0) {
+        companyId = (userWithCompanies.companies[0] as any).companyId;
+      }
+    }
+
+    if (!companyId) {
+      res.status(400).json({
+        success: false,
+        error: 'Company ID required',
+      });
+      return;
+    }
+
+    // Check if user has access to this company
+    const membership = await prisma.companyMember.findUnique({
+      where: {
+        userId_companyId: {
+          userId: user.id,
+          companyId: companyId as string,
+        },
+      },
+      include: {
+        company: true,
+      },
+    });
+
+    if (!membership) {
+      res.status(403).json({
+        success: false,
+        error: 'Access denied to this company',
+      });
+      return;
+    }
+
+    // Attach company info to request
+    (req as any).company = membership.company;
+    (req as any).membership = {
+      role: (membership as any).role,
+      permissions: (membership as any).permissions,
+    };
+
+    next();
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Company authorization failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
+/**
+ * Company admin guard
+ * Ensures user is an admin or owner of the company
+ */
+export async function companyAdminGuard(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    // First run company guard
+    await companyGuard(req, res, () => {});
+    
+    if (res.headersSent) {
+      return;
+    }
+
+    const membership = (req as any).membership;
+
+    if (!membership || !['admin', 'owner'].includes(membership.role)) {
+      res.status(403).json({
+        success: false,
+        error: 'Admin access required',
+      });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Admin authorization failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}

--- a/backend/src/common/logger/logger.service.ts
+++ b/backend/src/common/logger/logger.service.ts
@@ -1,0 +1,179 @@
+import winston from 'winston';
+import path from 'path';
+
+export class Logger {
+  private logger: winston.Logger;
+  private context: string;
+
+  constructor(context: string) {
+    this.context = context;
+    
+    const logLevel = process.env.LOG_LEVEL || 'info';
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    // Define log format
+    const logFormat = winston.format.combine(
+      winston.format.timestamp({
+        format: 'YYYY-MM-DD HH:mm:ss',
+      }),
+      winston.format.errors({ stack: true }),
+      winston.format.splat(),
+      winston.format.json(),
+      winston.format.printf(({ timestamp, level, message, context, ...metadata }) => {
+        let msg = `${timestamp} [${level.toUpperCase()}] [${context}] ${message}`;
+        
+        if (Object.keys(metadata).length > 0) {
+          msg += ` ${JSON.stringify(metadata)}`;
+        }
+        
+        return msg;
+      })
+    );
+
+    // Create transports
+    const transports: winston.transport[] = [
+      // Console transport
+      new winston.transports.Console({
+        format: isProduction
+          ? logFormat
+          : winston.format.combine(
+              winston.format.colorize(),
+              winston.format.simple(),
+              logFormat
+            ),
+      }),
+    ];
+
+    // Add file transport in production
+    if (isProduction) {
+      transports.push(
+        new winston.transports.File({
+          filename: path.join(process.env.LOG_DIR || './logs', 'error.log'),
+          level: 'error',
+          maxsize: 5242880, // 5MB
+          maxFiles: 5,
+        }),
+        new winston.transports.File({
+          filename: path.join(process.env.LOG_DIR || './logs', 'combined.log'),
+          maxsize: 5242880, // 5MB
+          maxFiles: 5,
+        })
+      );
+    }
+
+    // Create logger instance
+    this.logger = winston.createLogger({
+      level: logLevel,
+      format: logFormat,
+      defaultMeta: { context: this.context },
+      transports,
+    });
+  }
+
+  info(message: string, ...meta: any[]): void {
+    this.logger.info(message, ...meta);
+  }
+
+  error(message: string, error?: any, ...meta: any[]): void {
+    if (error instanceof Error) {
+      this.logger.error(message, {
+        error: {
+          message: error.message,
+          stack: error.stack,
+          name: error.name,
+        },
+        ...meta,
+      });
+    } else {
+      this.logger.error(message, error, ...meta);
+    }
+  }
+
+  warn(message: string, ...meta: any[]): void {
+    this.logger.warn(message, ...meta);
+  }
+
+  debug(message: string, ...meta: any[]): void {
+    this.logger.debug(message, ...meta);
+  }
+
+  verbose(message: string, ...meta: any[]): void {
+    this.logger.verbose(message, ...meta);
+  }
+
+  /**
+   * Log method execution time
+   */
+  time(label: string): () => void {
+    const start = Date.now();
+    return () => {
+      const duration = Date.now() - start;
+      this.debug(`${label} took ${duration}ms`);
+    };
+  }
+
+  /**
+   * Create a child logger with additional context
+   */
+  child(context: string): Logger {
+    return new Logger(`${this.context}:${context}`);
+  }
+
+  /**
+   * Log HTTP request
+   */
+  logRequest(req: any, res: any, responseTime: number): void {
+    const { method, url, headers, ip } = req;
+    const { statusCode } = res;
+
+    const logData = {
+      method,
+      url,
+      statusCode,
+      responseTime: `${responseTime}ms`,
+      ip: ip || req.connection.remoteAddress,
+      userAgent: headers['user-agent'],
+      userId: req.user?.id,
+    };
+
+    if (statusCode >= 400) {
+      this.warn('HTTP Request Error', logData);
+    } else {
+      this.info('HTTP Request', logData);
+    }
+  }
+
+  /**
+   * Log database query
+   */
+  logQuery(query: string, params: any[], duration: number): void {
+    if (process.env.LOG_QUERIES === 'true') {
+      this.debug('Database Query', {
+        query,
+        params,
+        duration: `${duration}ms`,
+      });
+    }
+  }
+
+  /**
+   * Log external API call
+   */
+  logApiCall(service: string, endpoint: string, duration: number, status: number): void {
+    const logData = {
+      service,
+      endpoint,
+      duration: `${duration}ms`,
+      status,
+    };
+
+    if (status >= 400) {
+      this.error('External API Error', logData);
+    } else {
+      this.info('External API Call', logData);
+    }
+  }
+}
+
+// Export singleton for global logger
+export const globalLogger = new Logger('App');

--- a/backend/src/common/middleware/validation.middleware.ts
+++ b/backend/src/common/middleware/validation.middleware.ts
@@ -1,0 +1,122 @@
+import { Request, Response, NextFunction } from 'express';
+import { validate } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+
+/**
+ * Validation middleware factory
+ */
+export function validateDto(dtoClass: any) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Transform plain object to DTO instance
+      const dto = plainToClass(dtoClass, req.body);
+
+      // Validate DTO
+      const errors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: true,
+      });
+
+      if (errors.length > 0) {
+        const errorMessages = errors.map(error => {
+          const constraints = error.constraints || {};
+          return {
+            property: error.property,
+            errors: Object.values(constraints),
+          };
+        });
+
+        return res.status(400).json({
+          success: false,
+          error: 'Validation failed',
+          details: errorMessages,
+        });
+      }
+
+      // Replace request body with validated DTO
+      req.body = dto;
+      next();
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: 'Validation error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}
+
+/**
+ * Validate query parameters
+ */
+export function validateQuery(dtoClass: any) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const dto = plainToClass(dtoClass, req.query);
+      const errors = await validate(dto);
+
+      if (errors.length > 0) {
+        const errorMessages = errors.map(error => {
+          const constraints = error.constraints || {};
+          return {
+            property: error.property,
+            errors: Object.values(constraints),
+          };
+        });
+
+        return res.status(400).json({
+          success: false,
+          error: 'Query validation failed',
+          details: errorMessages,
+        });
+      }
+
+      req.query = dto as any;
+      next();
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: 'Query validation error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}
+
+/**
+ * Validate request params
+ */
+export function validateParams(dtoClass: any) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const dto = plainToClass(dtoClass, req.params);
+      const errors = await validate(dto);
+
+      if (errors.length > 0) {
+        const errorMessages = errors.map(error => {
+          const constraints = error.constraints || {};
+          return {
+            property: error.property,
+            errors: Object.values(constraints),
+          };
+        });
+
+        return res.status(400).json({
+          success: false,
+          error: 'Params validation failed',
+          details: errorMessages,
+        });
+      }
+
+      req.params = dto as any;
+      next();
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: 'Params validation error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/backend/src/common/queue/queue.service.ts
+++ b/backend/src/common/queue/queue.service.ts
@@ -1,0 +1,244 @@
+import PgBoss from 'pg-boss';
+import { Logger } from '../logger/logger.service';
+
+export class QueueService {
+  private static instance: QueueService;
+  private boss: PgBoss;
+  private logger: Logger;
+  private isStarted: boolean = false;
+
+  private constructor() {
+    this.logger = new Logger('QueueService');
+    
+    // Initialize pg-boss with your existing PostgreSQL connection
+    this.boss = new PgBoss({
+      connectionString: process.env.DATABASE_URL,
+      // Use a schema to keep job tables organized
+      schema: 'pgboss',
+      // Retention settings
+      retentionDays: 30,
+      retryLimit: 3,
+      retryDelay: 60,
+      // Monitoring
+      monitorStateIntervalSeconds: 30,
+    });
+
+    this.initialize();
+  }
+
+  public static getInstance(): QueueService {
+    if (!QueueService.instance) {
+      QueueService.instance = new QueueService();
+    }
+    return QueueService.instance;
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      await this.boss.start();
+      this.isStarted = true;
+      this.logger.info('Queue service started successfully');
+      
+      // Setup job handlers
+      this.setupHandlers();
+      
+      // Setup recurring jobs
+      await this.setupRecurringJobs();
+    } catch (error) {
+      this.logger.error('Failed to start queue service', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Add a job to the queue
+   */
+  async addJob<T = any>(
+    name: string,
+    data: T,
+    options?: PgBoss.SendOptions
+  ): Promise<string | null> {
+    if (!this.isStarted) {
+      throw new Error('Queue service not started');
+    }
+
+    try {
+      const jobId = await this.boss.send(name, data, options);
+      this.logger.debug(`Job ${name} added with ID: ${jobId}`);
+      return jobId;
+    } catch (error) {
+      this.logger.error(`Failed to add job ${name}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Schedule a recurring job
+   */
+  async scheduleJob(
+    name: string,
+    cron: string,
+    data?: any,
+    options?: PgBoss.ScheduleOptions
+  ): Promise<void> {
+    try {
+      await this.boss.schedule(name, cron, data, options);
+      this.logger.info(`Scheduled job ${name} with cron: ${cron}`);
+    } catch (error) {
+      this.logger.error(`Failed to schedule job ${name}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Process jobs
+   */
+  async processJobs<T = any>(
+    name: string,
+    handler: (job: PgBoss.Job<T>) => Promise<void>,
+    options?: PgBoss.WorkOptions
+  ): Promise<void> {
+    try {
+      await this.boss.work(name, options || {}, async (job) => {
+        this.logger.debug(`Processing job ${name}:${job.id}`);
+        
+        try {
+          await handler(job);
+          this.logger.debug(`Job ${name}:${job.id} completed`);
+        } catch (error) {
+          this.logger.error(`Job ${name}:${job.id} failed`, error);
+          throw error;
+        }
+      });
+    } catch (error) {
+      this.logger.error(`Failed to setup job processor for ${name}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Setup job handlers
+   */
+  private setupHandlers(): void {
+    // Model retraining handler
+    this.processJobs('retrain-model', async (job) => {
+      const { companyId, userId } = job.data;
+      
+      // Import and use the learning service
+      const { LearningService } = await import('../../modules/timeTracking/learning-engine/learning.service');
+      const learningService = new LearningService();
+      
+      await learningService.trainModel({ companyId, userId });
+    });
+
+    // Timer auto-stop handler
+    this.processJobs('auto-stop-timer', async (job) => {
+      const { timerId } = job.data;
+      
+      const { TimerService } = await import('../../modules/timeTracking/timer.service');
+      const timerService = new TimerService();
+      
+      // Implementation for auto-stopping timer
+      this.logger.info(`Auto-stopping timer ${timerId}`);
+    });
+
+    // Monthly report generation
+    this.processJobs('generate-monthly-report', async (job) => {
+      const { companyId, month, year } = job.data;
+      
+      // Generate and email monthly reports
+      this.logger.info(`Generating monthly report for ${companyId}`);
+    });
+  }
+
+  /**
+   * Setup recurring jobs
+   */
+  private async setupRecurringJobs(): Promise<void> {
+    // Monthly model retraining - First day of each month at 2 AM
+    await this.scheduleJob(
+      'monthly-retrain-all',
+      '0 2 1 * *',
+      {},
+      { tz: 'UTC' }
+    );
+
+    // Weekly analytics aggregation - Every Sunday at 3 AM
+    await this.scheduleJob(
+      'weekly-analytics',
+      '0 3 * * 0',
+      {},
+      { tz: 'UTC' }
+    );
+
+    // Daily timer cleanup - Every day at midnight
+    await this.scheduleJob(
+      'daily-timer-cleanup',
+      '0 0 * * *',
+      {},
+      { tz: 'UTC' }
+    );
+
+    this.logger.info('Recurring jobs scheduled');
+  }
+
+  /**
+   * Get job status
+   */
+  async getJobStatus(jobId: string): Promise<PgBoss.Job | null> {
+    try {
+      const job = await this.boss.getJobById(jobId);
+      return job;
+    } catch (error) {
+      this.logger.error(`Failed to get job status for ${jobId}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Cancel a job
+   */
+  async cancelJob(jobId: string): Promise<void> {
+    try {
+      await this.boss.cancel(jobId);
+      this.logger.info(`Job ${jobId} cancelled`);
+    } catch (error) {
+      this.logger.error(`Failed to cancel job ${jobId}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get queue statistics
+   */
+  async getStats(): Promise<any> {
+    try {
+      const states = await this.boss.getQueueSize();
+      const completedCount = await this.boss.getCompletedCount();
+      const failedCount = await this.boss.getFailedCount();
+
+      return {
+        queued: states,
+        completed: completedCount,
+        failed: failedCount,
+      };
+    } catch (error) {
+      this.logger.error('Failed to get queue stats', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gracefully shutdown
+   */
+  async shutdown(): Promise<void> {
+    if (this.isStarted) {
+      await this.boss.stop();
+      this.isStarted = false;
+      this.logger.info('Queue service stopped');
+    }
+  }
+}
+
+// Export singleton instance
+export const queueService = QueueService.getInstance();

--- a/backend/src/common/scheduler/simple-scheduler.ts
+++ b/backend/src/common/scheduler/simple-scheduler.ts
@@ -1,0 +1,129 @@
+import { Logger } from '../logger/logger.service';
+
+interface ScheduledJob {
+  name: string;
+  schedule: string; // cron expression or 'daily' | 'weekly' | 'monthly'
+  handler: () => Promise<void>;
+  lastRun?: Date;
+  nextRun: Date;
+}
+
+export class SimpleScheduler {
+  private static instance: SimpleScheduler;
+  private jobs: Map<string, ScheduledJob> = new Map();
+  private intervalId: NodeJS.Timeout | null = null;
+  private logger: Logger;
+
+  private constructor() {
+    this.logger = new Logger('SimpleScheduler');
+    this.start();
+  }
+
+  public static getInstance(): SimpleScheduler {
+    if (!SimpleScheduler.instance) {
+      SimpleScheduler.instance = new SimpleScheduler();
+    }
+    return SimpleScheduler.instance;
+  }
+
+  /**
+   * Register a job
+   */
+  public registerJob(name: string, schedule: string, handler: () => Promise<void>): void {
+    const nextRun = this.calculateNextRun(schedule);
+    
+    this.jobs.set(name, {
+      name,
+      schedule,
+      handler,
+      nextRun,
+    });
+
+    this.logger.info(`Job registered: ${name}, next run: ${nextRun}`);
+  }
+
+  /**
+   * Start the scheduler
+   */
+  private start(): void {
+    // Check for jobs every minute
+    this.intervalId = setInterval(() => {
+      this.checkAndRunJobs();
+    }, 60 * 1000); // 1 minute
+
+    this.logger.info('Scheduler started');
+  }
+
+  /**
+   * Check and run due jobs
+   */
+  private async checkAndRunJobs(): Promise<void> {
+    const now = new Date();
+
+    for (const [name, job] of this.jobs) {
+      if (now >= job.nextRun) {
+        this.logger.info(`Running job: ${name}`);
+        
+        try {
+          // Run job
+          await job.handler();
+          
+          // Update last run and calculate next run
+          job.lastRun = now;
+          job.nextRun = this.calculateNextRun(job.schedule, now);
+          
+          this.logger.info(`Job completed: ${name}, next run: ${job.nextRun}`);
+        } catch (error) {
+          this.logger.error(`Job failed: ${name}`, error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Calculate next run time
+   */
+  private calculateNextRun(schedule: string, fromDate?: Date): Date {
+    const from = fromDate || new Date();
+    const next = new Date(from);
+
+    switch (schedule) {
+      case 'daily':
+        next.setDate(next.getDate() + 1);
+        next.setHours(2, 0, 0, 0); // 2 AM
+        break;
+
+      case 'weekly':
+        next.setDate(next.getDate() + 7);
+        next.setHours(2, 0, 0, 0); // 2 AM on same day next week
+        break;
+
+      case 'monthly':
+        next.setMonth(next.getMonth() + 1);
+        next.setDate(1);
+        next.setHours(2, 0, 0, 0); // 2 AM on first day of next month
+        break;
+
+      default:
+        // For now, default to daily
+        next.setDate(next.getDate() + 1);
+        next.setHours(2, 0, 0, 0);
+    }
+
+    return next;
+  }
+
+  /**
+   * Stop the scheduler
+   */
+  public stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.logger.info('Scheduler stopped');
+    }
+  }
+}
+
+// Export singleton
+export const scheduler = SimpleScheduler.getInstance();

--- a/backend/src/modules/timeTracking/dto/time-entry.dto.ts
+++ b/backend/src/modules/timeTracking/dto/time-entry.dto.ts
@@ -1,0 +1,226 @@
+import { 
+  IsString, 
+  IsNotEmpty, 
+  IsOptional, 
+  IsDateString, 
+  IsNumber, 
+  Min, 
+  Max,
+  IsBoolean,
+  IsEnum 
+} from 'class-validator';
+
+export class TimeEntryDto {
+  @IsString()
+  @IsNotEmpty()
+  taskId: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  startTime: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  endTime: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(86400) // Max 24 hours in seconds
+  duration?: number;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isManual?: boolean;
+}
+
+export class UpdateTimeEntryDto {
+  @IsOptional()
+  @IsDateString()
+  startTime?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endTime?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(86400) // Max 24 hours in seconds
+  duration?: number;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+export class ListTimeEntriesDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @IsString()
+  taskId?: string;
+
+  @IsOptional()
+  @IsString()
+  projectId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class TimeEntryStatsDto {
+  @IsOptional()
+  @IsEnum(['day', 'week', 'month', 'year'])
+  period?: 'day' | 'week' | 'month' | 'year';
+
+  @IsOptional()
+  @IsEnum(['day', 'week', 'task', 'project'])
+  groupBy?: 'day' | 'week' | 'task' | 'project';
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}
+
+export class ExportTimeEntriesDto {
+  @IsOptional()
+  @IsEnum(['csv', 'pdf', 'excel'])
+  format?: 'csv' | 'pdf' | 'excel';
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @IsString()
+  projectId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  includeDescription?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  groupByProject?: boolean;
+}
+
+export class BulkTimeEntryDto {
+  @IsNotEmpty()
+  entries: TimeEntryDto[];
+}
+
+/**
+ * Response DTOs
+ */
+export class TimeEntryResponseDto {
+  id: string;
+  taskId: string;
+  userId: string;
+  companyId: string;
+  startTime: Date;
+  endTime: Date;
+  duration: number;
+  description?: string;
+  isManual: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  task?: {
+    id: string;
+    title: string;
+    project?: {
+      id: string;
+      name: string;
+      color: string;
+    };
+  };
+  user?: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+export class TimeEntryStatsResponseDto {
+  period: {
+    start: Date;
+    end: Date;
+  };
+  groupedData: Array<{
+    date?: Date;
+    week?: string;
+    taskId?: string;
+    taskTitle?: string;
+    projectId?: string;
+    projectName?: string;
+    duration: number;
+    count: number;
+  }>;
+  insights: {
+    averageSessionLength: number;
+    mostProductiveTimeOfDay: string;
+    longestSession: {
+      duration: number;
+      taskId: string;
+      taskTitle: string;
+      date: Date;
+    };
+    focusScore: number;
+    consistencyScore: number;
+    velocityTrend: number;
+  };
+  summary: {
+    totalTime: number;
+    totalEntries: number;
+    averageSessionLength: number;
+    mostProductiveTime: string;
+    longestSession: number;
+  };
+}
+
+export class TimerStateResponseDto {
+  id: string;
+  taskId: string;
+  userId: string;
+  companyId: string;
+  startTime: Date;
+  pausedAt?: Date;
+  totalPausedDuration: number;
+  isActive: boolean;
+  isPaused: boolean;
+  currentDuration?: number;
+  task?: {
+    id: string;
+    title: string;
+    project?: {
+      id: string;
+      name: string;
+    };
+  };
+}

--- a/backend/src/modules/timeTracking/dto/timer-action.dto.ts
+++ b/backend/src/modules/timeTracking/dto/timer-action.dto.ts
@@ -1,0 +1,64 @@
+import { IsString, IsNotEmpty, IsOptional, IsDateString } from 'class-validator';
+
+export class TimerActionDto {
+  @IsString()
+  @IsNotEmpty()
+  taskId: string;
+
+  @IsOptional()
+  @IsDateString()
+  timestamp?: string;
+}
+
+export class StartTimerDto extends TimerActionDto {
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+export class StopTimerDto extends TimerActionDto {
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  summary?: string;
+}
+
+export class PauseTimerDto extends TimerActionDto {
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
+export class SyncTimersDto {
+  @IsNotEmpty()
+  timers: TimerStateDto[];
+}
+
+export class TimerStateDto {
+  @IsString()
+  @IsNotEmpty()
+  taskId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  companyId: string;
+
+  @IsDateString()
+  startTime: string;
+
+  @IsOptional()
+  @IsDateString()
+  pausedAt?: string;
+
+  @IsNotEmpty()
+  totalPausedDuration: number;
+
+  @IsNotEmpty()
+  isActive: boolean;
+
+  @IsNotEmpty()
+  isPaused: boolean;
+}

--- a/backend/src/modules/timeTracking/learning-engine/learning.service.ts
+++ b/backend/src/modules/timeTracking/learning-engine/learning.service.ts
@@ -1,0 +1,388 @@
+import { PrismaClient } from '@prisma/client';
+import { FeatureExtractor } from './feature-extractor';
+import { ModelTrainer } from './model-trainer';
+import { PredictionService } from './prediction.service';
+import { queueService } from '../../../common/queue/queue.service';
+import { Logger } from '../../../common/logger/logger.service';
+
+interface ModelMetrics {
+  accuracy: number;
+  meanAbsoluteError: number;
+  meanSquaredError: number;
+  r2Score: number;
+  lastTrainedAt: Date;
+  dataPointsUsed: number;
+}
+
+interface TrainingResult {
+  modelId: string;
+  version: string;
+  metrics: ModelMetrics;
+  improvements: {
+    accuracyDelta: number;
+    maeDelta: number;
+  };
+}
+
+export class LearningService {
+  private prisma: PrismaClient;
+  private featureExtractor: FeatureExtractor;
+  private modelTrainer: ModelTrainer;
+  private predictionService: PredictionService;
+  private logger: Logger;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.featureExtractor = new FeatureExtractor();
+    this.modelTrainer = new ModelTrainer();
+    this.predictionService = new PredictionService();
+    this.logger = new Logger('LearningService');
+
+    // Setup job processors
+    this.setupJobProcessors();
+  }
+
+  /**
+   * Trigger model retraining
+   */
+  async triggerRetraining(params: {
+    companyId?: string;
+    userId?: string;
+    force?: boolean;
+  }): Promise<string> {
+    const { companyId, userId, force = false } = params;
+
+    if (!force) {
+      const shouldRetrain = await this.shouldRetrain({ companyId, userId });
+      if (!shouldRetrain) {
+        this.logger.info('Retraining not needed based on current metrics');
+        return 'skipped';
+      }
+    }
+
+    const jobId = await queueService.addJob('retrain-model', {
+      companyId,
+      userId,
+      timestamp: new Date(),
+    }, {
+      priority: 10,
+      retryLimit: 2,
+      retryDelay: 300,
+    });
+
+    this.logger.info(`Retraining job queued: ${jobId}`);
+    return jobId || 'queued';
+  }
+
+  /**
+   * Prepare data for training
+   */
+  async prepareTrainingData(params: {
+    companyId?: string;
+    userId?: string;
+    minDataPoints?: number;
+  }): Promise<any> {
+    const { companyId, userId, minDataPoints = 100 } = params;
+
+    const where: any = {};
+    if (companyId) where.companyId = companyId;
+    if (userId) where.userId = userId;
+
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        ...where,
+        status: 'done',
+        timeSpent: { gt: 0 },
+        timeEntries: { some: {} },
+      },
+      include: {
+        timeEntries: true,
+        project: true,
+        assignee: {
+          select: {
+            id: true,
+            preferences: true,
+          },
+        },
+        tags: true,
+        subtasks: true,
+        dependencies: true,
+      },
+    });
+
+    if (tasks.length < minDataPoints) {
+      throw new Error(`Insufficient data for training. Need ${minDataPoints}, have ${tasks.length}`);
+    }
+
+    const trainingData = await Promise.all(
+      tasks.map(async (task) => {
+        const features = await this.featureExtractor.extractFeatures(task);
+        const actualDuration = task.timeSpent;
+        const estimatedDuration = task.estimatedTime || 0;
+
+        return {
+          features,
+          target: actualDuration,
+          metadata: {
+            taskId: task.id,
+            estimatedDuration,
+            error: Math.abs(actualDuration - estimatedDuration),
+          },
+        };
+      })
+    );
+
+    const splitIndex = Math.floor(trainingData.length * 0.8);
+    const shuffled = trainingData.sort(() => Math.random() - 0.5);
+
+    return {
+      training: shuffled.slice(0, splitIndex),
+      validation: shuffled.slice(splitIndex),
+      totalSamples: trainingData.length,
+    };
+  }
+
+  /**
+   * Train and evaluate model
+   */
+  async trainModel(params: {
+    companyId?: string;
+    userId?: string;
+  }): Promise<TrainingResult> {
+    const { companyId, userId } = params;
+
+    try {
+      const data = await this.prepareTrainingData({ companyId, userId });
+
+      const currentMetrics = await this.getCurrentModelMetrics({ companyId, userId });
+
+      const trainedModel = await this.modelTrainer.train({
+        trainingData: data.training,
+        validationData: data.validation,
+        hyperparameters: {
+          learningRate: 0.001,
+          epochs: 100,
+          batchSize: 32,
+          hiddenLayers: [64, 32, 16],
+          dropout: 0.2,
+          earlyStopping: {
+            patience: 10,
+            minDelta: 0.001,
+          },
+        },
+      });
+
+      const metrics = await this.modelTrainer.evaluate({
+        model: trainedModel,
+        testData: data.validation,
+      });
+
+      const improvements = {
+        accuracyDelta: metrics.accuracy - (currentMetrics?.accuracy || 0),
+        maeDelta: (currentMetrics?.meanAbsoluteError || Infinity) - metrics.meanAbsoluteError,
+      };
+
+      if (improvements.accuracyDelta > 0 || improvements.maeDelta > 0) {
+        await this.deployModel({
+          model: trainedModel,
+          metrics,
+          companyId,
+          userId,
+        });
+
+        this.logger.info('Model deployed with improvements', improvements);
+      } else {
+        this.logger.info('Model not deployed - no improvements', improvements);
+      }
+
+      return {
+        modelId: trainedModel.id,
+        version: trainedModel.version,
+        metrics,
+        improvements,
+      };
+    } catch (error) {
+      this.logger.error('Model training failed', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deploy trained model
+   */
+  private async deployModel(params: {
+    model: any;
+    metrics: ModelMetrics;
+    companyId?: string;
+    userId?: string;
+  }): Promise<void> {
+    const { model, metrics, companyId, userId } = params;
+
+    const modelKey = this.generateModelKey({ companyId, userId });
+
+    const modelData = {
+      architecture: model.model.toJSON(),
+      weights: model.model.getWeights().map((w: any) => ({
+        values: Array.from(w.dataSync()),
+        shape: w.shape,
+      })),
+      inputShape: model.model.inputs[0].shape.slice(1),
+    };
+
+    await this.prisma.mLModel.upsert({
+      where: {
+        key: modelKey,
+      },
+      create: {
+        key: modelKey,
+        companyId,
+        userId,
+        version: model.version,
+        modelData: modelData as any,
+        metadata: {
+          featureNames: model.featureNames,
+          normalizationParams: model.normalizationParams,
+        } as any,
+        metrics: metrics as any,
+        deployedAt: new Date(),
+        isActive: true,
+      },
+      update: {
+        version: model.version,
+        modelData: modelData as any,
+        metadata: {
+          featureNames: model.featureNames,
+          normalizationParams: model.normalizationParams,
+        } as any,
+        metrics: metrics as any,
+        deployedAt: new Date(),
+        isActive: true,
+      },
+    });
+
+    await this.predictionService.reloadModel(modelKey);
+
+    await this.prisma.modelDeployment.create({
+      data: {
+        modelKey,
+        version: model.version,
+        metrics: metrics as any,
+        deployedAt: new Date(),
+        deployedBy: userId || 'system',
+      },
+    });
+  }
+
+  /**
+   * Check if model should be retrained
+   */
+  private async shouldRetrain(params: {
+    companyId?: string;
+    userId?: string;
+  }): Promise<boolean> {
+    const { companyId, userId } = params;
+    const modelKey = this.generateModelKey({ companyId, userId });
+
+    const currentModel = await this.prisma.mLModel.findUnique({
+      where: { key: modelKey },
+    });
+
+    if (!currentModel) {
+      return true;
+    }
+
+    const daysSinceTraining = 
+      (Date.now() - (currentModel.deployedAt as any).getTime()) / (1000 * 60 * 60 * 24);
+    
+    if (daysSinceTraining >= 30) {
+      return true;
+    }
+
+    const recentPredictions = await this.prisma.prediction.findMany({
+      where: {
+        modelKey,
+        createdAt: {
+          gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+        },
+        actualValue: { not: null },
+      },
+    });
+
+    if (recentPredictions.length < 10) {
+      return false;
+    }
+
+    const recentMae = recentPredictions.reduce((sum, pred) => {
+      return sum + Math.abs(pred.predictedValue - (pred.actualValue as number));
+    }, 0) / recentPredictions.length;
+
+    const currentMae = (currentModel.metrics as any).meanAbsoluteError;
+    const degradation = (recentMae - currentMae) / currentMae;
+
+    return degradation > 0.2;
+  }
+
+  private async getCurrentModelMetrics(params: {
+    companyId?: string;
+    userId?: string;
+  }): Promise<ModelMetrics | null> {
+    const modelKey = this.generateModelKey(params);
+
+    const model = await this.prisma.mLModel.findUnique({
+      where: { key: modelKey },
+    });
+
+    return model ? (model.metrics as any) : null;
+  }
+
+  private setupJobProcessors(): void {
+    queueService.processJobs('retrain-model', async (job) => {
+      const { companyId, userId } = job.data;
+      return await this.trainModel({ companyId, userId });
+    });
+
+    queueService.processJobs('monthly-retrain-all', async () => {
+      const activeModels = await this.prisma.mLModel.findMany({
+        where: { isActive: true },
+      });
+
+      const jobs = await Promise.all(
+        activeModels.map(model => 
+          this.triggerRetraining({
+            companyId: model.companyId || undefined,
+            userId: model.userId || undefined,
+          })
+        )
+      );
+
+      return { modelsQueued: jobs.length };
+    });
+  }
+
+  private generateModelKey(params: {
+    companyId?: string;
+    userId?: string;
+  }): string {
+    const { companyId, userId } = params;
+    
+    if (userId) return `user_${userId}`;
+    if (companyId) return `company_${companyId}`;
+    return 'global';
+  }
+
+  async prepareABTest(params: {
+    modelA: string;
+    modelB: string;
+    splitRatio: number;
+  }): Promise<void> {
+    await this.prisma.aBTest.create({
+      data: {
+        modelAKey: params.modelA,
+        modelBKey: params.modelB,
+        splitRatio: params.splitRatio,
+        startedAt: new Date(),
+        isActive: true,
+      },
+    });
+  }
+}

--- a/backend/src/modules/timeTracking/learning-engine/scheduler-setup.ts
+++ b/backend/src/modules/timeTracking/learning-engine/scheduler-setup.ts
@@ -1,0 +1,112 @@
+import { scheduler } from '../../../common/scheduler/simple-scheduler';
+import { LearningService } from './learning.service';
+import { TimerService } from '../timer.service';
+import { PrismaClient } from '@prisma/client';
+import { Logger } from '../../../common/logger/logger.service';
+
+const logger = new Logger('SchedulerSetup');
+const prisma = new PrismaClient();
+
+export function setupScheduledJobs(): void {
+  // Monthly model retraining
+  scheduler.registerJob('monthly-model-retraining', 'monthly', async () => {
+    logger.info('Starting monthly model retraining');
+    
+    const learningService = new LearningService();
+    
+    // Get all active models
+    const activeModels = await prisma.mLModel.findMany({
+      where: { isActive: true },
+    });
+
+    for (const model of activeModels) {
+      try {
+        await learningService.triggerRetraining({
+          companyId: model.companyId || undefined,
+          userId: model.userId || undefined,
+        });
+      } catch (error) {
+        logger.error(`Failed to retrain model ${model.key}`, error);
+      }
+    }
+  });
+
+  // Daily timer cleanup
+  scheduler.registerJob('daily-timer-cleanup', 'daily', async () => {
+    logger.info('Running daily timer cleanup');
+    
+    const timerService = new TimerService();
+    
+    // Stop all active timers from previous day
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    
+    const staleTimers = await prisma.activeTimer.findMany({
+      where: {
+        isActive: true,
+        startTime: {
+          lt: yesterday,
+        },
+      },
+    });
+
+    for (const timer of staleTimers) {
+      await timerService.stopTimer({
+        taskId: timer.taskId,
+        userId: timer.userId,
+        companyId: timer.companyId,
+      });
+    }
+
+    logger.info(`Cleaned up ${staleTimers.length} stale timers`);
+  });
+
+  // Weekly analytics aggregation
+  scheduler.registerJob('weekly-analytics', 'weekly', async () => {
+    logger.info('Running weekly analytics aggregation');
+    
+    // Aggregate time tracking data for faster queries
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+    // Create weekly summaries
+    const result = await prisma.$executeRaw`
+      INSERT INTO weekly_summaries (user_id, company_id, week_start, total_time, task_count)
+      SELECT 
+        user_id,
+        company_id,
+        DATE_TRUNC('week', start_time) as week_start,
+        SUM(duration) as total_time,
+        COUNT(DISTINCT task_id) as task_count
+      FROM time_entries
+      WHERE start_time >= ${oneWeekAgo}
+      GROUP BY user_id, company_id, DATE_TRUNC('week', start_time)
+      ON CONFLICT (user_id, company_id, week_start) 
+      DO UPDATE SET 
+        total_time = EXCLUDED.total_time,
+        task_count = EXCLUDED.task_count
+    `;
+
+    logger.info(`Aggregated analytics for ${result} user-weeks`);
+  });
+
+  // Idle timer auto-pause (every 10 minutes)
+  setInterval(async () => {
+    const timerService = new TimerService();
+    await timerService.autoPauseInactiveTimers();
+  }, 10 * 60 * 1000); // 10 minutes
+
+  logger.info('All scheduled jobs registered');
+}
+
+// Initialize in your main app
+// backend/src/index.ts
+import { setupScheduledJobs } from './modules/timeTracking/learning-engine/scheduler-setup';
+
+// In your app initialization
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+  
+  // Setup scheduled jobs
+  setupScheduledJobs();
+});

--- a/backend/src/modules/timeTracking/repositories/time-entries.repository.ts
+++ b/backend/src/modules/timeTracking/repositories/time-entries.repository.ts
@@ -1,0 +1,523 @@
+import { PrismaClient } from '@prisma/client';
+import { Logger } from '../../../common/logger/logger.service';
+
+interface AggregationParams {
+  userId: string;
+  companyId: string;
+  startDate: Date;
+  endDate: Date;
+  groupBy: 'day' | 'week' | 'task' | 'project';
+}
+
+interface ProductivityInsightsParams {
+  userId: string;
+  companyId: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+interface TimeAggregation {
+  date?: Date;
+  week?: string;
+  taskId?: string;
+  taskTitle?: string;
+  projectId?: string;
+  projectName?: string;
+  duration: number;
+  count: number;
+}
+
+interface ProductivityInsights {
+  averageSessionLength: number;
+  mostProductiveTimeOfDay: string;
+  longestSession: {
+    duration: number;
+    taskId: string;
+    taskTitle: string;
+    date: Date;
+  };
+  focusScore: number;
+  consistencyScore: number;
+  velocityTrend: number;
+}
+
+export class TimeEntriesRepository {
+  private prisma: PrismaClient;
+  private logger: Logger;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.logger = new Logger('TimeEntriesRepository');
+  }
+
+  /**
+   * Get aggregated time statistics
+   */
+  async getAggregatedStats(params: AggregationParams): Promise<TimeAggregation[]> {
+    const { userId, companyId, startDate, endDate, groupBy } = params;
+
+    switch (groupBy) {
+      case 'day':
+        return this.aggregateByDay({ userId, companyId, startDate, endDate });
+      case 'week':
+        return this.aggregateByWeek({ userId, companyId, startDate, endDate });
+      case 'task':
+        return this.aggregateByTask({ userId, companyId, startDate, endDate });
+      case 'project':
+        return this.aggregateByProject({ userId, companyId, startDate, endDate });
+      default:
+        throw new Error(`Invalid groupBy parameter: ${groupBy}`);
+    }
+  }
+
+  /**
+   * Get productivity insights
+   */
+  async getProductivityInsights(params: ProductivityInsightsParams): Promise<ProductivityInsights> {
+    const { userId, companyId, startDate, endDate } = params;
+
+    const [
+      averageSessionLength,
+      mostProductiveTimeOfDay,
+      longestSession,
+      focusScore,
+      consistencyScore,
+      velocityTrend,
+    ] = await Promise.all([
+      this.calculateAverageSessionLength({ userId, companyId, startDate, endDate }),
+      this.findMostProductiveTimeOfDay({ userId, companyId, startDate, endDate }),
+      this.findLongestSession({ userId, companyId, startDate, endDate }),
+      this.calculateFocusScore({ userId, companyId, startDate, endDate }),
+      this.calculateConsistencyScore({ userId, companyId, startDate, endDate }),
+      this.calculateVelocityTrend({ userId, companyId, startDate, endDate }),
+    ]);
+
+    return {
+      averageSessionLength,
+      mostProductiveTimeOfDay,
+      longestSession,
+      focusScore,
+      consistencyScore,
+      velocityTrend,
+    };
+  }
+
+  /**
+   * Aggregate by day
+   */
+  private async aggregateByDay(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<TimeAggregation[]> {
+    const result = await this.prisma.$queryRaw<any[]>`
+      SELECT 
+        DATE(start_time) as date,
+        SUM(duration) as total_duration,
+        COUNT(*) as entry_count
+      FROM time_entries
+      WHERE user_id = ${params.userId}
+        AND company_id = ${params.companyId}
+        AND start_time >= ${params.startDate}
+        AND start_time <= ${params.endDate}
+      GROUP BY DATE(start_time)
+      ORDER BY date DESC
+    `;
+
+    return result.map(row => ({
+      date: new Date(row.date),
+      duration: Number(row.total_duration),
+      count: Number(row.entry_count),
+    }));
+  }
+
+  /**
+   * Aggregate by week
+   */
+  private async aggregateByWeek(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<TimeAggregation[]> {
+    const result = await this.prisma.$queryRaw<any[]>`
+      SELECT 
+        DATE_TRUNC('week', start_time) as week_start,
+        SUM(duration) as total_duration,
+        COUNT(*) as entry_count
+      FROM time_entries
+      WHERE user_id = ${params.userId}
+        AND company_id = ${params.companyId}
+        AND start_time >= ${params.startDate}
+        AND start_time <= ${params.endDate}
+      GROUP BY DATE_TRUNC('week', start_time)
+      ORDER BY week_start DESC
+    `;
+
+    return result.map(row => ({
+      week: new Date(row.week_start).toISOString().split('T')[0],
+      duration: Number(row.total_duration),
+      count: Number(row.entry_count),
+    }));
+  }
+
+  /**
+   * Aggregate by task
+   */
+  private async aggregateByTask(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<TimeAggregation[]> {
+    const result = await this.prisma.timeEntry.groupBy({
+      by: ['taskId'],
+      where: {
+        userId: params.userId,
+        companyId: params.companyId,
+        startTime: {
+          gte: params.startDate,
+          lte: params.endDate,
+        },
+      },
+      _sum: {
+        duration: true,
+      },
+      _count: true,
+    });
+
+    // Get task details
+    const taskIds = result.map(r => r.taskId);
+    const tasks = await this.prisma.task.findMany({
+      where: { id: { in: taskIds } },
+      select: { id: true, title: true },
+    });
+
+    const taskMap = new Map(tasks.map(t => [t.id, t.title]));
+
+    return result.map(row => ({
+      taskId: row.taskId,
+      taskTitle: taskMap.get(row.taskId) || 'Unknown Task',
+      duration: (row as any)._sum.duration || 0,
+      count: (row as any)._count,
+    }));
+  }
+
+  /**
+   * Aggregate by project
+   */
+  private async aggregateByProject(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<TimeAggregation[]> {
+    const result = await this.prisma.$queryRaw<any[]>`
+      SELECT 
+        t.project_id,
+        p.name as project_name,
+        SUM(te.duration) as total_duration,
+        COUNT(te.*) as entry_count
+      FROM time_entries te
+      JOIN tasks t ON te.task_id = t.id
+      LEFT JOIN projects p ON t.project_id = p.id
+      WHERE te.user_id = ${params.userId}
+        AND te.company_id = ${params.companyId}
+        AND te.start_time >= ${params.startDate}
+        AND te.start_time <= ${params.endDate}
+      GROUP BY t.project_id, p.name
+      ORDER BY total_duration DESC
+    `;
+
+    return result.map(row => ({
+      projectId: row.project_id,
+      projectName: row.project_name || 'No Project',
+      duration: Number(row.total_duration),
+      count: Number(row.entry_count),
+    }));
+  }
+
+  /**
+   * Calculate average session length
+   */
+  private async calculateAverageSessionLength(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<number> {
+    const result = await this.prisma.timeEntry.aggregate({
+      where: {
+        userId: params.userId,
+        companyId: params.companyId,
+        startTime: {
+          gte: params.startDate,
+          lte: params.endDate,
+        },
+      },
+      _avg: {
+        duration: true,
+      },
+    });
+
+    return (result as any)._avg.duration || 0;
+  }
+
+  /**
+   * Find most productive time of day
+   */
+  private async findMostProductiveTimeOfDay(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<string> {
+    const result = await this.prisma.$queryRaw<any[]>`
+      SELECT 
+        EXTRACT(HOUR FROM start_time) as hour,
+        SUM(duration) as total_duration,
+        COUNT(*) as session_count
+      FROM time_entries
+      WHERE user_id = ${params.userId}
+        AND company_id = ${params.companyId}
+        AND start_time >= ${params.startDate}
+        AND start_time <= ${params.endDate}
+      GROUP BY EXTRACT(HOUR FROM start_time)
+      ORDER BY total_duration DESC
+      LIMIT 1
+    `;
+
+    if (result.length === 0) return '9 AM - 10 AM';
+
+    const hour = Number(result[0].hour);
+    const period = hour < 12 ? 'AM' : 'PM';
+    const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+    
+    return `${displayHour} ${period} - ${displayHour + 1} ${period}`;
+  }
+
+  /**
+   * Find longest session
+   */
+  private async findLongestSession(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<any> {
+    const entry = await this.prisma.timeEntry.findFirst({
+      where: {
+        userId: params.userId,
+        companyId: params.companyId,
+        startTime: {
+          gte: params.startDate,
+          lte: params.endDate,
+        },
+      },
+      orderBy: {
+        duration: 'desc',
+      },
+      include: {
+        task: {
+          select: {
+            id: true,
+            title: true,
+          },
+        },
+      },
+    });
+
+    if (!entry) {
+      return {
+        duration: 0,
+        taskId: '',
+        taskTitle: 'No sessions found',
+        date: new Date(),
+      };
+    }
+
+    return {
+      duration: entry.duration,
+      taskId: entry.task.id,
+      taskTitle: entry.task.title,
+      date: entry.startTime,
+    };
+  }
+
+  /**
+   * Calculate focus score (0-100)
+   */
+  private async calculateFocusScore(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<number> {
+    const entries = await this.prisma.timeEntry.findMany({
+      where: {
+        userId: params.userId,
+        companyId: params.companyId,
+        startTime: {
+          gte: params.startDate,
+          lte: params.endDate,
+        },
+      },
+      orderBy: {
+        startTime: 'asc',
+      },
+      include: {
+        task: {
+          select: {
+            projectId: true,
+          },
+        },
+      },
+    });
+
+    if (entries.length === 0) return 50;
+
+    // Calculate average session length score
+    const avgDuration = entries.reduce((sum, e) => sum + e.duration, 0) / entries.length;
+    const sessionLengthScore = Math.min(avgDuration / 7200, 1) * 40; // 2 hours = perfect
+
+    // Calculate context switches
+    let contextSwitches = 0;
+    for (let i = 1; i < entries.length; i++) {
+      if (entries[i].task.projectId !== entries[i - 1].task.projectId) {
+        contextSwitches++;
+      }
+    }
+    const switchRatio = contextSwitches / entries.length;
+    const contextScore = (1 - Math.min(switchRatio, 1)) * 30;
+
+    // Calculate time gaps score
+    let totalGapTime = 0;
+    for (let i = 1; i < entries.length; i++) {
+      const gap = entries[i].startTime.getTime() - entries[i - 1].endTime.getTime();
+      totalGapTime += Math.max(0, gap);
+    }
+    const avgGap = totalGapTime / (entries.length - 1);
+    const gapScore = Math.max(0, 1 - (avgGap / (4 * 60 * 60 * 1000))) * 30; // 4 hours = 0 score
+
+    return Math.round(sessionLengthScore + contextScore + gapScore);
+  }
+
+  /**
+   * Calculate consistency score (0-100)
+   */
+  private async calculateConsistencyScore(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<number> {
+    const dailyStats = await this.aggregateByDay(params);
+
+    if (dailyStats.length < 2) return 50;
+
+    const durations = dailyStats.map(d => d.duration);
+    const avgDuration = durations.reduce((sum, d) => sum + d, 0) / durations.length;
+    
+    const variance = durations.reduce((sum, d) => sum + Math.pow(d - avgDuration, 2), 0) / durations.length;
+    const stdDev = Math.sqrt(variance);
+    
+    const cv = avgDuration > 0 ? stdDev / avgDuration : 1;
+    
+    const score = Math.max(0, 100 - (cv * 100));
+    
+    return Math.round(score);
+  }
+
+  /**
+   * Calculate velocity trend (-100 to +100)
+   */
+  private async calculateVelocityTrend(params: {
+    userId: string;
+    companyId: string;
+    startDate: Date;
+    endDate: Date;
+  }): Promise<number> {
+    const weeklyStats = await this.aggregateByWeek(params);
+
+    if (weeklyStats.length < 2) return 0;
+
+    const weeks = weeklyStats.map((_, i) => i);
+    const durations = weeklyStats.map(w => w.duration);
+
+    const n = weeks.length;
+    const sumX = weeks.reduce((sum, x) => sum + x, 0);
+    const sumY = durations.reduce((sum, y) => sum + y, 0);
+    const sumXY = weeks.reduce((sum, x, i) => sum + x * durations[i], 0);
+    const sumX2 = weeks.reduce((sum, x) => sum + x * x, 0);
+
+    const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+    
+    const avgDuration = sumY / n;
+    const normalizedSlope = avgDuration > 0 ? (slope / avgDuration) * 100 : 0;
+    
+    return Math.max(-100, Math.min(100, Math.round(normalizedSlope)));
+  }
+
+  /**
+   * Get export query data
+   */
+  async getExportData(params: {
+    userId: string;
+    companyId: string;
+    startDate?: Date;
+    endDate?: Date;
+    format: 'detailed' | 'summary';
+  }): Promise<any[]> {
+    const where: any = {
+      userId: params.userId,
+      companyId: params.companyId,
+    };
+
+    if (params.startDate) where.startTime = { gte: params.startDate };
+    if (params.endDate) {
+      where.startTime = where.startTime || {};
+      where.startTime.lte = params.endDate;
+    }
+
+    if (params.format === 'detailed') {
+      return this.prisma.timeEntry.findMany({
+        where,
+        include: {
+          task: {
+            include: {
+              project: {
+                select: {
+                  name: true,
+                  color: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          startTime: 'desc',
+        },
+      });
+    } else {
+      return this.prisma.$queryRaw`
+        SELECT 
+          p.name as project_name,
+          t.title as task_title,
+          SUM(te.duration) as total_duration,
+          COUNT(te.*) as entry_count,
+          MIN(te.start_time) as first_entry,
+          MAX(te.end_time) as last_entry
+        FROM time_entries te
+        JOIN tasks t ON te.task_id = t.id
+        LEFT JOIN projects p ON t.project_id = p.id
+        WHERE te.user_id = ${params.userId}
+          AND te.company_id = ${params.companyId}
+          ${params.startDate ? `AND te.start_time >= ${params.startDate}` : ''}
+          ${params.endDate ? `AND te.start_time <= ${params.endDate}` : ''}
+        GROUP BY p.name, t.title
+        ORDER BY total_duration DESC
+      `;
+    }
+  }
+}

--- a/backend/src/modules/timeTracking/time-entries.service.ts
+++ b/backend/src/modules/timeTracking/time-entries.service.ts
@@ -1,0 +1,587 @@
+import { PrismaClient } from '@prisma/client';
+import { TimeEntriesRepository } from './repositories/time-entries.repository';
+import { parse } from 'csv-parse/sync';
+import { PDFDocument, rgb } from 'pdf-lib';
+import * as ExcelJS from 'exceljs';
+import { Logger } from '../../common/logger/logger.service';
+
+interface CreateEntryParams {
+  taskId: string;
+  userId: string;
+  companyId: string;
+  startTime: Date;
+  endTime: Date;
+  duration: number;
+  description?: string;
+}
+
+interface UpdateEntryParams {
+  id: string;
+  userId: string;
+  companyId: string;
+  startTime?: Date;
+  endTime?: Date;
+  duration?: number;
+  description?: string;
+}
+
+interface ListEntriesParams {
+  userId: string;
+  companyId: string;
+  startDate?: Date;
+  endDate?: Date;
+  taskId?: string;
+  projectId?: string;
+  pagination: {
+    page: number;
+    limit: number;
+  };
+}
+
+interface ExportParams {
+  userId: string;
+  companyId: string;
+  format: 'csv' | 'pdf' | 'excel';
+  startDate?: Date;
+  endDate?: Date;
+}
+
+interface StatisticsParams {
+  userId: string;
+  companyId: string;
+  period: 'day' | 'week' | 'month' | 'year';
+  groupBy: 'day' | 'week' | 'task' | 'project';
+}
+
+export class TimeEntriesService {
+  private prisma: PrismaClient;
+  private repository: TimeEntriesRepository;
+  private logger: Logger;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.repository = new TimeEntriesRepository();
+    this.logger = new Logger('TimeEntriesService');
+  }
+
+  /**
+   * Create a new time entry
+   */
+  async createEntry(params: CreateEntryParams): Promise<any> {
+    const { taskId, userId, companyId, startTime, endTime, duration, description } = params;
+
+    // Validate no overlaps
+    const hasOverlap = await this.checkOverlap({
+      userId,
+      startTime,
+      endTime,
+      excludeId: undefined,
+    });
+
+    if (hasOverlap) {
+      throw new Error('Time entry overlaps with existing entries');
+    }
+
+    // Create the entry
+    const timeEntry = await this.prisma.timeEntry.create({
+      data: {
+        taskId,
+        userId,
+        companyId,
+        startTime,
+        endTime,
+        duration,
+        description,
+        isManual: false,
+      },
+      include: {
+        task: {
+          include: {
+            project: true,
+          },
+        },
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    this.logger.info(`Time entry created: ${timeEntry.id}`);
+
+    return timeEntry;
+  }
+
+  /**
+   * Update an existing time entry
+   */
+  async updateEntry(params: UpdateEntryParams): Promise<any> {
+    const { id, userId, companyId, ...updateData } = params;
+
+    // Check ownership
+    const existingEntry = await this.prisma.timeEntry.findFirst({
+      where: {
+        id,
+        userId,
+        companyId,
+      },
+    });
+
+    if (!existingEntry) {
+      throw new Error('Time entry not found or access denied');
+    }
+
+    // If updating time range, check for overlaps
+    if (updateData.startTime || updateData.endTime) {
+      const startTime = updateData.startTime || existingEntry.startTime;
+      const endTime = updateData.endTime || existingEntry.endTime;
+
+      const hasOverlap = await this.checkOverlap({
+        userId,
+        startTime,
+        endTime,
+        excludeId: id,
+      });
+
+      if (hasOverlap) {
+        throw new Error('Updated time range overlaps with existing entries');
+      }
+
+      // Recalculate duration if times changed
+      updateData.duration = Math.floor((endTime.getTime() - startTime.getTime()) / 1000);
+    }
+
+    // Update the entry
+    const updatedEntry = await this.prisma.timeEntry.update({
+      where: { id },
+      data: {
+        ...updateData,
+        isManual: true, // Mark as manually edited
+      },
+      include: {
+        task: {
+          include: {
+            project: true,
+          },
+        },
+      },
+    });
+
+    this.logger.info(`Time entry updated: ${id}`);
+
+    return updatedEntry;
+  }
+
+  /**
+   * Delete a time entry
+   */
+  async deleteEntry(params: { id: string; userId: string; companyId: string }): Promise<void> {
+    const { id, userId, companyId } = params;
+
+    // Check ownership
+    const entry = await this.prisma.timeEntry.findFirst({
+      where: {
+        id,
+        userId,
+        companyId,
+      },
+    });
+
+    if (!entry) {
+      throw new Error('Time entry not found or access denied');
+    }
+
+    // Update task time spent
+    await this.prisma.task.update({
+      where: { id: entry.taskId },
+      data: {
+        timeSpent: {
+          decrement: entry.duration,
+        },
+      },
+    });
+
+    // Delete the entry
+    await this.prisma.timeEntry.delete({
+      where: { id },
+    });
+
+    this.logger.info(`Time entry deleted: ${id}`);
+  }
+
+  /**
+   * List time entries with filtering and pagination
+   */
+  async listEntries(params: ListEntriesParams): Promise<any> {
+    const { userId, companyId, startDate, endDate, taskId, projectId, pagination } = params;
+
+    const where: any = {
+      userId,
+      companyId,
+    };
+
+    if (startDate || endDate) {
+      where.startTime = {};
+      if (startDate) where.startTime.gte = startDate;
+      if (endDate) where.startTime.lte = endDate;
+    }
+
+    if (taskId) where.taskId = taskId;
+    if (projectId) where.task = { projectId };
+
+    const [entries, total] = await Promise.all([
+      this.prisma.timeEntry.findMany({
+        where,
+        include: {
+          task: {
+            include: {
+              project: {
+                select: {
+                  id: true,
+                  name: true,
+                  color: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: { startTime: 'desc' },
+        skip: (pagination.page - 1) * pagination.limit,
+        take: pagination.limit,
+      }),
+      this.prisma.timeEntry.count({ where }),
+    ]);
+
+    return {
+      data: entries,
+      meta: {
+        total,
+        page: pagination.page,
+        limit: pagination.limit,
+        totalPages: Math.ceil(total / pagination.limit),
+      },
+    };
+  }
+
+  /**
+   * Get time tracking statistics
+   */
+  async getStatistics(params: StatisticsParams): Promise<any> {
+    const { userId, companyId, period, groupBy } = params;
+
+    // Calculate date range based on period
+    const endDate = new Date();
+    const startDate = new Date();
+
+    switch (period) {
+      case 'day':
+        startDate.setHours(0, 0, 0, 0);
+        break;
+      case 'week':
+        startDate.setDate(startDate.getDate() - 7);
+        break;
+      case 'month':
+        startDate.setMonth(startDate.getMonth() - 1);
+        break;
+      case 'year':
+        startDate.setFullYear(startDate.getFullYear() - 1);
+        break;
+    }
+
+    // Get aggregated data from repository
+    const stats = await this.repository.getAggregatedStats({
+      userId,
+      companyId,
+      startDate,
+      endDate,
+      groupBy,
+    });
+
+    // Get additional insights
+    const insights = await this.repository.getProductivityInsights({
+      userId,
+      companyId,
+      startDate,
+      endDate,
+    });
+
+    return {
+      period: {
+        start: startDate,
+        end: endDate,
+      },
+      groupedData: stats,
+      insights,
+      summary: {
+        totalTime: stats.reduce((sum: number, item: any) => sum + item.duration, 0),
+        totalEntries: stats.reduce((sum: number, item: any) => sum + item.count, 0),
+        averageSessionLength: insights.averageSessionLength,
+        mostProductiveTime: insights.mostProductiveTimeOfDay,
+        longestSession: insights.longestSession,
+      },
+    };
+  }
+
+  /**
+   * Export time entries in various formats
+   */
+  async exportEntries(params: ExportParams): Promise<any> {
+    const { userId, companyId, format, startDate, endDate } = params;
+
+    // Get all entries for export
+    const entries = await this.prisma.timeEntry.findMany({
+      where: {
+        userId,
+        companyId,
+        ...(startDate && { startTime: { gte: startDate } }),
+        ...(endDate && { endTime: { lte: endDate } }),
+      },
+      include: {
+        task: {
+          include: {
+            project: true,
+          },
+        },
+      },
+      orderBy: { startTime: 'asc' },
+    });
+
+    let exportData: Buffer;
+    let contentType: string;
+    let filename: string;
+
+    switch (format) {
+      case 'csv':
+        exportData = await this.exportToCSV(entries);
+        contentType = 'text/csv';
+        filename = `time-entries-${Date.now()}.csv`;
+        break;
+
+      case 'pdf':
+        exportData = await this.exportToPDF(entries);
+        contentType = 'application/pdf';
+        filename = `time-entries-${Date.now()}.pdf`;
+        break;
+
+      case 'excel':
+        exportData = await this.exportToExcel(entries);
+        contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        filename = `time-entries-${Date.now()}.xlsx`;
+        break;
+
+      default:
+        throw new Error('Unsupported export format');
+    }
+
+    return {
+      data: exportData,
+      contentType,
+      filename,
+    };
+  }
+
+  /**
+   * Check for overlapping time entries
+   */
+  private async checkOverlap(params: {
+    userId: string;
+    startTime: Date;
+    endTime: Date;
+    excludeId?: string;
+  }): Promise<boolean> {
+    const { userId, startTime, endTime, excludeId } = params;
+
+    const overlapping = await this.prisma.timeEntry.findFirst({
+      where: {
+        userId,
+        id: excludeId ? { not: excludeId } : undefined,
+        OR: [
+          {
+            AND: [
+              { startTime: { lte: startTime } },
+              { endTime: { gt: startTime } },
+            ],
+          },
+          {
+            AND: [
+              { startTime: { lt: endTime } },
+              { endTime: { gte: endTime } },
+            ],
+          },
+          {
+            AND: [
+              { startTime: { gte: startTime } },
+              { endTime: { lte: endTime } },
+            ],
+          },
+        ],
+      },
+    });
+
+    return !!overlapping;
+  }
+
+  /**
+   * Export entries to CSV format
+   */
+  private async exportToCSV(entries: any[]): Promise<Buffer> {
+    const headers = [
+      'Date',
+      'Start Time',
+      'End Time',
+      'Duration (minutes)',
+      'Project',
+      'Task',
+      'Description',
+    ];
+
+    const rows = entries.map(entry => [
+      entry.startTime.toLocaleDateString(),
+      entry.startTime.toLocaleTimeString(),
+      entry.endTime.toLocaleTimeString(),
+      Math.round(entry.duration / 60),
+      entry.task.project?.name || '',
+      entry.task.title,
+      entry.description || '',
+    ]);
+
+    const csvContent = [
+      headers.join(','),
+      ...rows.map(row => row.map(cell => `"${cell}"`).join(',')),
+    ].join('\n');
+
+    return Buffer.from(csvContent, 'utf-8');
+  }
+
+  /**
+   * Export entries to PDF format
+   */
+  private async exportToPDF(entries: any[]): Promise<Buffer> {
+    const pdfDoc = await PDFDocument.create();
+    let page = pdfDoc.addPage();
+    const { height } = page.getSize();
+    let yPosition = height - 50;
+
+    // Title
+    page.drawText('Time Tracking Report', {
+      x: 50,
+      y: yPosition,
+      size: 20,
+      color: rgb(0, 0, 0),
+    });
+
+    yPosition -= 40;
+
+    // Table headers
+    const headers = ['Date', 'Time', 'Duration', 'Project', 'Task'];
+    const columnWidths = [80, 100, 60, 100, 150];
+    let xPosition = 50;
+
+    headers.forEach((header, index) => {
+      page.drawText(header, {
+        x: xPosition,
+        y: yPosition,
+        size: 12,
+        color: rgb(0, 0, 0),
+      });
+      xPosition += columnWidths[index];
+    });
+
+    yPosition -= 20;
+
+    // Table rows
+    for (const entry of entries) {
+      if (yPosition < 50) {
+        page = pdfDoc.addPage();
+        yPosition = height - 50;
+      }
+
+      xPosition = 50;
+      const row = [
+        entry.startTime.toLocaleDateString(),
+        `${entry.startTime.toLocaleTimeString()} - ${entry.endTime.toLocaleTimeString()}`,
+        `${Math.round(entry.duration / 60)}m`,
+        entry.task.project?.name || '-',
+        entry.task.title,
+      ];
+
+      row.forEach((cell, index) => {
+        page.drawText(cell.substring(0, 20), {
+          x: xPosition,
+          y: yPosition,
+          size: 10,
+          color: rgb(0, 0, 0),
+        });
+        xPosition += columnWidths[index];
+      });
+
+      yPosition -= 15;
+    }
+
+    // Summary
+    yPosition -= 20;
+    const totalMinutes = entries.reduce((sum, entry) => sum + entry.duration, 0) / 60;
+    page.drawText(`Total Time: ${Math.round(totalMinutes)} minutes`, {
+      x: 50,
+      y: yPosition,
+      size: 12,
+      color: rgb(0, 0, 0),
+    });
+
+    const pdfBytes = await pdfDoc.save();
+    return Buffer.from(pdfBytes);
+  }
+
+  /**
+   * Export entries to Excel format
+   */
+  private async exportToExcel(entries: any[]): Promise<Buffer> {
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('Time Entries');
+
+    // Add headers
+    worksheet.columns = [
+      { header: 'Date', key: 'date', width: 15 },
+      { header: 'Start Time', key: 'startTime', width: 15 },
+      { header: 'End Time', key: 'endTime', width: 15 },
+      { header: 'Duration (min)', key: 'duration', width: 15 },
+      { header: 'Project', key: 'project', width: 20 },
+      { header: 'Task', key: 'task', width: 30 },
+      { header: 'Description', key: 'description', width: 40 },
+    ];
+
+    // Add rows
+    entries.forEach(entry => {
+      worksheet.addRow({
+        date: entry.startTime.toLocaleDateString(),
+        startTime: entry.startTime.toLocaleTimeString(),
+        endTime: entry.endTime.toLocaleTimeString(),
+        duration: Math.round(entry.duration / 60),
+        project: entry.task.project?.name || '',
+        task: entry.task.title,
+        description: entry.description || '',
+      });
+    });
+
+    // Add summary row
+    worksheet.addRow({});
+    worksheet.addRow({
+      date: 'Total',
+      duration: entries.reduce((sum, entry) => sum + Math.round(entry.duration / 60), 0),
+    });
+
+    // Style the header row
+    worksheet.getRow(1).font = { bold: true };
+    worksheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFE0E0E0' },
+    };
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
+  }
+}

--- a/backend/src/modules/timeTracking/time-tracking.controller.ts
+++ b/backend/src/modules/timeTracking/time-tracking.controller.ts
@@ -1,0 +1,384 @@
+import { Request, Response, Router } from 'express';
+import { TimerService } from './timer.service';
+import { TimeEntriesService } from './time-entries.service';
+import { authGuard } from '../auth/guards/auth.guard';
+import { companyGuard } from '../../common/guards/company.guard';
+import { validateDto } from '../../common/middleware/validation.middleware';
+import { TimerActionDto } from './dto/timer-action.dto';
+import { TimeEntryDto } from './dto/time-entry.dto';
+
+export class TimeTrackingController {
+  public router: Router = Router();
+  private timerService: TimerService;
+  private timeEntriesService: TimeEntriesService;
+
+  constructor() {
+    this.timerService = new TimerService();
+    this.timeEntriesService = new TimeEntriesService();
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes(): void {
+    // Timer endpoints
+    this.router.post(
+      '/time-entries/start',
+      authGuard,
+      companyGuard,
+      validateDto(TimerActionDto),
+      this.startTimer
+    );
+
+    this.router.post(
+      '/time-entries/stop',
+      authGuard,
+      companyGuard,
+      validateDto(TimerActionDto),
+      this.stopTimer
+    );
+
+    this.router.post(
+      '/time-entries/pause',
+      authGuard,
+      companyGuard,
+      validateDto(TimerActionDto),
+      this.pauseTimer
+    );
+
+    // Time entries CRUD
+    this.router.get(
+      '/time-entries',
+      authGuard,
+      companyGuard,
+      this.listTimeEntries
+    );
+
+    this.router.put(
+      '/time-entries/:id',
+      authGuard,
+      companyGuard,
+      validateDto(TimeEntryDto),
+      this.updateTimeEntry
+    );
+
+    this.router.delete(
+      '/time-entries/:id',
+      authGuard,
+      companyGuard,
+      this.deleteTimeEntry
+    );
+
+    // Analytics endpoints
+    this.router.get(
+      '/time-entries/stats',
+      authGuard,
+      companyGuard,
+      this.getTimeStats
+    );
+
+    this.router.get(
+      '/time-entries/export',
+      authGuard,
+      companyGuard,
+      this.exportTimeEntries
+    );
+
+    // Polling endpoint for timer updates
+    this.router.get(
+      '/timers/updates',
+      authGuard,
+      companyGuard,
+      this.getTimerUpdates
+    );
+
+    // Timer state endpoints
+    this.router.get(
+      '/timers/active',
+      authGuard,
+      companyGuard,
+      this.getActiveTimers
+    );
+
+    this.router.post(
+      '/timers/sync',
+      authGuard,
+      companyGuard,
+      this.syncTimerState
+    );
+  }
+
+  /**
+   * Start a timer for a task
+   */
+  private startTimer = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { taskId } = req.body;
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+
+      const timer = await this.timerService.startTimer({
+        taskId,
+        userId,
+        companyId,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: timer,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Stop a timer and create time entry
+   */
+  private stopTimer = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { taskId } = req.body;
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+
+      const timeEntry = await this.timerService.stopTimer({
+        taskId,
+        userId,
+        companyId,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: timeEntry,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Pause a running timer
+   */
+  private pauseTimer = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { taskId } = req.body;
+      const userId = (req as any).user.id;
+
+      const timer = await this.timerService.pauseTimer({
+        taskId,
+        userId,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: timer,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * List time entries with filtering
+   */
+  private listTimeEntries = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+      const { startDate, endDate, taskId, projectId, page = 1, limit = 50 } = req.query;
+
+      const entries = await this.timeEntriesService.listEntries({
+        userId,
+        companyId,
+        startDate: startDate ? new Date(startDate as string) : undefined,
+        endDate: endDate ? new Date(endDate as string) : undefined,
+        taskId: taskId as string,
+        projectId: projectId as string,
+        pagination: {
+          page: Number(page),
+          limit: Number(limit),
+        },
+      });
+
+      res.status(200).json({
+        success: true,
+        data: entries.data,
+        meta: entries.meta,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Update a time entry
+   */
+  private updateTimeEntry = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+
+      const updatedEntry = await this.timeEntriesService.updateEntry({
+        id,
+        userId,
+        companyId,
+        ...req.body,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: updatedEntry,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Delete a time entry
+   */
+  private deleteTimeEntry = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+
+      await this.timeEntriesService.deleteEntry({
+        id,
+        userId,
+        companyId,
+      });
+
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Get time tracking statistics
+   */
+  private getTimeStats = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+      const { period = 'week', groupBy = 'day' } = req.query;
+
+      const stats = await this.timeEntriesService.getStatistics({
+        userId,
+        companyId,
+        period: period as 'day' | 'week' | 'month' | 'year',
+        groupBy: groupBy as 'day' | 'week' | 'task' | 'project',
+      });
+
+      res.status(200).json({
+        success: true,
+        data: stats,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Export time entries to CSV/PDF
+   */
+  private exportTimeEntries = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+      const { format = 'csv', startDate, endDate } = req.query;
+
+      const exportData = await this.timeEntriesService.exportEntries({
+        userId,
+        companyId,
+        format: format as 'csv' | 'pdf' | 'excel',
+        startDate: startDate ? new Date(startDate as string) : undefined,
+        endDate: endDate ? new Date(endDate as string) : undefined,
+      });
+
+      res.setHeader('Content-Type', exportData.contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${exportData.filename}"`);
+      res.send(exportData.data);
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Get all active timers for the user
+   */
+  private getActiveTimers = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user.id;
+      const companyId = (req as any).company.id;
+
+      const timers = await this.timerService.getActiveTimers({
+        userId,
+        companyId,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: timers,
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+
+  /**
+   * Get timer updates for polling
+   */
+  private getTimerUpdates = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const companyId = (req as any).company.id;
+      const { since, userId } = req.query;
+
+      const sinceDate = since ? new Date(since as string) : new Date(Date.now() - 60000); // Default: last minute
+
+      const updates = await this.timerService.getTimerUpdates({
+        companyId,
+        since: sinceDate,
+        userId: userId as string,
+      });
+
+      res.status(200).json({
+        success: true,
+        data: updates,
+        timestamp: new Date(),
+      });
+    } catch (error: any) {
+      res.status(400).json({
+        success: false,
+        error: error.message,
+      });
+    }
+  };
+}

--- a/backend/src/modules/timeTracking/timer.service.ts
+++ b/backend/src/modules/timeTracking/timer.service.ts
@@ -1,0 +1,571 @@
+import { PrismaClient } from '@prisma/client';
+import { TimeEntriesService } from './time-entries.service';
+import { EventEmitter } from 'events';
+import { Logger } from '../../common/logger/logger.service';
+
+interface TimerState {
+  id: string;
+  taskId: string;
+  userId: string;
+  companyId: string;
+  startTime: Date;
+  pausedAt?: Date;
+  totalPausedDuration: number;
+  isActive: boolean;
+  isPaused: boolean;
+}
+
+interface StartTimerParams {
+  taskId: string;
+  userId: string;
+  companyId: string;
+}
+
+interface StopTimerParams {
+  taskId: string;
+  userId: string;
+  companyId: string;
+}
+
+interface PauseTimerParams {
+  taskId: string;
+  userId: string;
+}
+
+export class TimerService {
+  private prisma: PrismaClient;
+  private timeEntriesService: TimeEntriesService;
+  private eventEmitter: EventEmitter;
+  private logger: Logger;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.timeEntriesService = new TimeEntriesService();
+    this.eventEmitter = new EventEmitter();
+    this.logger = new Logger('TimerService');
+
+    // Initialize automatic timer stop at day end
+    this.initializeDayEndHandler();
+  }
+
+  /**
+   * Start a timer for a task
+   */
+  async startTimer(params: StartTimerParams): Promise<TimerState> {
+    const { taskId, userId, companyId } = params;
+
+    // Check if task exists and user has access
+    const task = await this.prisma.task.findFirst({
+      where: {
+        id: taskId,
+        companyId,
+        OR: [
+          { assigneeId: userId },
+          { createdById: userId },
+          { collaborators: { some: { userId } } },
+        ],
+      },
+    });
+
+    if (!task) {
+      throw new Error('Task not found or access denied');
+    }
+
+    // Stop any other active timers for this user (single transaction)
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Stop active timers
+      await tx.activeTimer.updateMany({
+        where: {
+          userId,
+          isActive: true,
+          isPaused: false,
+        },
+        data: {
+          isActive: false,
+          endTime: new Date(),
+        },
+      });
+
+      // Create new timer
+      return await tx.activeTimer.create({
+        data: {
+          taskId,
+          userId,
+          companyId,
+          startTime: new Date(),
+          totalPausedDuration: 0,
+          isActive: true,
+          isPaused: false,
+        },
+      });
+    });
+
+    this.logger.info(`Timer started for task ${taskId} by user ${userId}`);
+
+    return {
+      id: result.id,
+      taskId: result.taskId,
+      userId: result.userId,
+      companyId: result.companyId,
+      startTime: result.startTime,
+      totalPausedDuration: result.totalPausedDuration,
+      isActive: result.isActive,
+      isPaused: result.isPaused,
+    };
+  }
+
+  /**
+   * Stop a timer and create time entry
+   */
+  async stopTimer(params: StopTimerParams): Promise<any> {
+    const { taskId, userId, companyId } = params;
+
+    // Get active timer from database
+    const timer = await this.prisma.activeTimer.findFirst({
+      where: {
+        taskId,
+        userId,
+        companyId,
+        isActive: true,
+      },
+    });
+
+    if (!timer) {
+      throw new Error('No active timer found for this task');
+    }
+
+    // Calculate total duration
+    const endTime = new Date();
+    const totalDuration = this.calculateDuration(timer, endTime);
+
+    // Use transaction to ensure consistency
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Mark timer as inactive
+      await tx.activeTimer.update({
+        where: { id: timer.id },
+        data: {
+          isActive: false,
+          endTime,
+        },
+      });
+
+      // Update task time spent
+      await tx.task.update({
+        where: { id: taskId },
+        data: {
+          timeSpent: {
+            increment: totalDuration,
+          },
+        },
+      });
+
+      // Create time entry via service (outside transaction if it has its own)
+      return { timer, totalDuration };
+    });
+
+    // Create time entry
+    const timeEntry = await this.timeEntriesService.createEntry({
+      taskId,
+      userId,
+      companyId,
+      startTime: timer.startTime,
+      endTime,
+      duration: result.totalDuration,
+      description: '',
+    });
+
+    this.logger.info(`Timer stopped for task ${taskId} by user ${userId}, duration: ${result.totalDuration}s`);
+
+    return timeEntry;
+  }
+
+  /**
+   * Pause a running timer
+   */
+  async pauseTimer(params: PauseTimerParams): Promise<TimerState> {
+    const { taskId, userId } = params;
+
+    const timer = await this.prisma.activeTimer.findFirst({
+      where: {
+        taskId,
+        userId,
+        isActive: true,
+      },
+    });
+
+    if (!timer) {
+      throw new Error('No active timer found for this task');
+    }
+
+    let updatedTimer;
+
+    if (timer.isPaused) {
+      // Resume timer
+      const pauseDuration = Date.now() - new Date(timer.pausedAt!).getTime();
+      
+      updatedTimer = await this.prisma.activeTimer.update({
+        where: { id: timer.id },
+        data: {
+          isPaused: false,
+          pausedAt: null,
+          totalPausedDuration: {
+            increment: pauseDuration,
+          },
+        },
+      });
+    } else {
+      // Pause timer
+      updatedTimer = await this.prisma.activeTimer.update({
+        where: { id: timer.id },
+        data: {
+          isPaused: true,
+          pausedAt: new Date(),
+        },
+      });
+    }
+
+    return {
+      id: updatedTimer.id,
+      taskId: updatedTimer.taskId,
+      userId: updatedTimer.userId,
+      companyId: updatedTimer.companyId,
+      startTime: updatedTimer.startTime,
+      pausedAt: updatedTimer.pausedAt || undefined,
+      totalPausedDuration: updatedTimer.totalPausedDuration,
+      isActive: updatedTimer.isActive,
+      isPaused: updatedTimer.isPaused,
+    };
+  }
+
+  /**
+   * Get all active timers for a user
+   */
+  async getActiveTimers(params: { userId: string; companyId: string }): Promise<TimerState[]> {
+    const { userId, companyId } = params;
+    
+    const timers = await this.prisma.activeTimer.findMany({
+      where: {
+        userId,
+        companyId,
+        isActive: true,
+      },
+      include: {
+        task: {
+          select: {
+            title: true,
+            project: {
+              select: {
+                name: true,
+                color: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return timers.map(timer => ({
+      id: timer.id,
+      taskId: timer.taskId,
+      userId: timer.userId,
+      companyId: timer.companyId,
+      startTime: timer.startTime,
+      pausedAt: timer.pausedAt || undefined,
+      totalPausedDuration: timer.totalPausedDuration,
+      isActive: timer.isActive,
+      isPaused: timer.isPaused,
+      currentDuration: this.calculateDuration(timer, new Date()),
+    }));
+  }
+
+  /**
+   * Get timer updates since a timestamp (for polling)
+   */
+  async getTimerUpdates(params: {
+    companyId: string;
+    since: Date;
+    userId?: string;
+  }): Promise<any[]> {
+    const { companyId, since, userId } = params;
+
+    const where: any = {
+      companyId,
+      updatedAt: { gt: since },
+    };
+
+    if (userId) {
+      where.userId = userId;
+    }
+
+    const updates = await this.prisma.activeTimer.findMany({
+      where,
+      include: {
+        task: {
+          select: {
+            title: true,
+          },
+        },
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        updatedAt: 'desc',
+      },
+    });
+
+    return updates.map(timer => ({
+      ...timer,
+      currentDuration: timer.isActive ? this.calculateDuration(timer, new Date()) : null,
+      eventType: timer.isActive ? 'timer_updated' : 'timer_stopped',
+    }));
+  }
+
+  /**
+   * Get timer state for multiple users (for dashboard)
+   */
+  async getMultipleUserTimers(userIds: string[]): Promise<Map<string, TimerState[]>> {
+    const timers = await this.prisma.activeTimer.findMany({
+      where: {
+        userId: { in: userIds },
+        isActive: true,
+      },
+    });
+
+    const userTimers = new Map<string, TimerState[]>();
+
+    for (const userId of userIds) {
+      const userTimerStates = timers
+        .filter(t => t.userId === userId)
+        .map(timer => ({
+          id: timer.id,
+          taskId: timer.taskId,
+          userId: timer.userId,
+          companyId: timer.companyId,
+          startTime: timer.startTime,
+          pausedAt: timer.pausedAt || undefined,
+          totalPausedDuration: timer.totalPausedDuration,
+          isActive: timer.isActive,
+          isPaused: timer.isPaused,
+          currentDuration: this.calculateDuration(timer, new Date()),
+        }));
+      
+      userTimers.set(userId, userTimerStates);
+    }
+
+    return userTimers;
+  }
+
+  /**
+   * Sync timer state from client (for offline support)
+   */
+  async syncTimerState(params: { userId: string; timers: any[] }): Promise<TimerState[]> {
+    const { userId, timers } = params;
+    const syncedTimers: TimerState[] = [];
+
+    for (const clientTimer of timers) {
+      const serverTimer = await this.prisma.activeTimer.findFirst({
+        where: {
+          taskId: clientTimer.taskId,
+          userId,
+          isActive: true,
+        },
+      });
+
+      if (serverTimer) {
+        // Merge with server state
+        const mergedTimer = await this.mergeTimerStates(serverTimer, clientTimer);
+        syncedTimers.push(mergedTimer);
+      } else {
+        // Client has timer that server doesn't know about
+        if (clientTimer.isActive) {
+          const newTimer = await this.startTimer({
+            taskId: clientTimer.taskId,
+            userId,
+            companyId: clientTimer.companyId,
+          });
+          syncedTimers.push(newTimer);
+        }
+      }
+    }
+
+    return syncedTimers;
+  }
+
+  /**
+   * Stop all active timers for a user
+   */
+  private async stopAllActiveTimers(userId: string): Promise<void> {
+    const activeTimers = await this.prisma.activeTimer.findMany({
+      where: {
+        userId,
+        isActive: true,
+        isPaused: false,
+      },
+    });
+
+    for (const timer of activeTimers) {
+      await this.stopTimer({
+        taskId: timer.taskId,
+        userId: timer.userId,
+        companyId: timer.companyId,
+      });
+    }
+  }
+
+  /**
+   * Calculate duration accounting for pauses
+   */
+  private calculateDuration(timer: any, endTime: Date): number {
+    const startMs = new Date(timer.startTime).getTime();
+    const endMs = endTime.getTime();
+    let totalMs = endMs - startMs;
+
+    // Subtract paused duration
+    totalMs -= timer.totalPausedDuration;
+
+    // If currently paused, subtract current pause duration
+    if (timer.isPaused && timer.pausedAt) {
+      const currentPauseDuration = endMs - new Date(timer.pausedAt).getTime();
+      totalMs -= currentPauseDuration;
+    }
+
+    return Math.floor(totalMs / 1000); // Return in seconds
+  }
+
+  /**
+   * Merge client and server timer states
+   */
+  private async mergeTimerStates(serverTimer: any, clientTimer: any): Promise<TimerState> {
+    // Server state takes precedence, but we consider client's pause state
+    const mergedData = {
+      isPaused: clientTimer.isPaused || serverTimer.isPaused,
+      totalPausedDuration: Math.max(
+        serverTimer.totalPausedDuration,
+        clientTimer.totalPausedDuration || 0
+      ),
+    };
+
+    const updated = await this.prisma.activeTimer.update({
+      where: { id: serverTimer.id },
+      data: mergedData,
+    });
+
+    return {
+      id: updated.id,
+      taskId: updated.taskId,
+      userId: updated.userId,
+      companyId: updated.companyId,
+      startTime: updated.startTime,
+      pausedAt: updated.pausedAt || undefined,
+      totalPausedDuration: updated.totalPausedDuration,
+      isActive: updated.isActive,
+      isPaused: updated.isPaused,
+    };
+  }
+
+  /**
+   * Initialize automatic timer stop at day end
+   */
+  private initializeDayEndHandler(): void {
+    // Schedule job to run at midnight
+    const scheduleNextDayEnd = () => {
+      const now = new Date();
+      const tomorrow = new Date(now);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+
+      const msUntilMidnight = tomorrow.getTime() - now.getTime();
+
+      setTimeout(async () => {
+        await this.stopAllTimersAtDayEnd();
+        scheduleNextDayEnd(); // Schedule for next day
+      }, msUntilMidnight);
+    };
+
+    scheduleNextDayEnd();
+  }
+
+  /**
+   * Stop all active timers at day end
+   */
+  private async stopAllTimersAtDayEnd(): Promise<void> {
+    this.logger.info('Running day-end timer cleanup');
+
+    const activeTimers = await this.prisma.activeTimer.findMany({
+      where: {
+        isActive: true,
+      },
+    });
+
+    for (const timer of activeTimers) {
+      try {
+        await this.stopTimer({
+          taskId: timer.taskId,
+          userId: timer.userId,
+          companyId: timer.companyId,
+        });
+
+        // Create notification for user
+        await this.prisma.notification.create({
+          data: {
+            userId: timer.userId,
+            type: 'timer_auto_stopped',
+            title: 'Timer automatically stopped',
+            message: 'Your timer was automatically stopped at the end of the day',
+            data: {
+              taskId: timer.taskId,
+              reason: 'day_end',
+            },
+          },
+        });
+      } catch (error) {
+        this.logger.error(`Failed to stop timer ${timer.id}:`, error);
+      }
+    }
+  }
+
+  /**
+   * Auto-pause inactive timers (called by cron job)
+   */
+  async autoPauseInactiveTimers(): Promise<void> {
+    const inactiveThreshold = 10 * 60 * 1000; // 10 minutes
+    const cutoffTime = new Date(Date.now() - inactiveThreshold);
+
+    // Find timers that haven't been updated recently
+    const inactiveTimers = await this.prisma.activeTimer.findMany({
+      where: {
+        isActive: true,
+        isPaused: false,
+        updatedAt: {
+          lt: cutoffTime,
+        },
+      },
+    });
+
+    for (const timer of inactiveTimers) {
+      await this.pauseTimer({
+        taskId: timer.taskId,
+        userId: timer.userId,
+      });
+
+      await this.prisma.notification.create({
+        data: {
+          userId: timer.userId,
+          type: 'timer_auto_paused',
+          title: 'Timer paused due to inactivity',
+          message: 'Your timer was paused after 10 minutes of inactivity',
+          data: {
+            taskId: timer.taskId,
+            reason: 'idle',
+          },
+        },
+      });
+    }
+
+    this.logger.info(`Auto-paused ${inactiveTimers.length} inactive timers`);
+  }
+}

--- a/backend/src/workers/job-processor.ts
+++ b/backend/src/workers/job-processor.ts
@@ -1,0 +1,38 @@
+import { queueService } from '../common/queue/queue.service';
+import { Logger } from '../common/logger/logger.service';
+
+const logger = new Logger('JobProcessor');
+
+async function startWorker() {
+  logger.info('Starting job processor worker...');
+
+  // Graceful shutdown handlers
+  process.on('SIGTERM', async () => {
+    logger.info('SIGTERM received, shutting down gracefully...');
+    await queueService.shutdown();
+    process.exit(0);
+  });
+
+  process.on('SIGINT', async () => {
+    logger.info('SIGINT received, shutting down gracefully...');
+    await queueService.shutdown();
+    process.exit(0);
+  });
+
+  // Keep the process alive
+  setInterval(() => {
+    logger.debug('Worker heartbeat');
+  }, 30000); // Every 30 seconds
+}
+
+// Start the worker
+startWorker().catch((error) => {
+  logger.error('Worker failed to start', error);
+  process.exit(1);
+});
+
+// For Railway deployment, you can run this as a separate service
+// railway.toml:
+// [[services]]
+// name = "worker"
+// startCommand = "npm run jobs:worker"


### PR DESCRIPTION
## Summary
- add basic logger, queue and scheduler utilities
- implement time tracking services and controller
- include DTOs and repository for time entries
- add background worker setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bac96530c832297c1eb2aec639b53